### PR TITLE
Fix release pipeline permissions for uploading UefiExt.dll

### DIFF
--- a/.github/workflows/Build-UefiExt.yaml
+++ b/.github/workflows/Build-UefiExt.yaml
@@ -30,7 +30,7 @@ jobs:
         platform: [x64]
     runs-on: windows-2022
     permissions:
-      contents: read
+      contents: write
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/Build-UefiExt.yaml
+++ b/.github/workflows/Build-UefiExt.yaml
@@ -29,6 +29,8 @@ jobs:
         configuration: [Debug, Release]
         platform: [x64]
     runs-on: windows-2022
+    permissions:
+      contents: read
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Adds write permissions to release contents for the UefiExt build pipeline for it to upload the release artifact.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Manually tested in test release

## Integration Instructions

N/A
