### PR TITLE
Change local in debug agent to static to fix compile error

### DIFF
--- a/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.c
@@ -31,7 +31,7 @@ extern EFI_TIMER_ARCH_PROTOCOL  *gTimer;
 extern EFI_BOOT_SERVICES        mBootServices;
 extern EFI_RUNTIME_SERVICES     *gDxeCoreRT;
 
-EFI_MEMORY_ATTRIBUTE_PROTOCOL  *mMemoryAttributeProtocol = NULL;
+STATIC EFI_MEMORY_ATTRIBUTE_PROTOCOL  *mMemoryAttributeProtocol = NULL;
 
 CONST CHAR8  *gDebuggerInfo = "DXE UEFI Debugger";
 


### PR DESCRIPTION
## Description

Fixes a common local name to STATIC to avoid compile errors. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Local compile and test

## Integration Instructions

N/A