### PR TITLE
Fix CodeQL issue for delimiter index in GDB parsing

### DIFF
--- a/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStub.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStub.c
@@ -282,8 +282,8 @@ ProcessVCommand (
   UINT32  CommandLength
   )
 {
-  UINT8  OriginalDelimiter;
-  UINT8  DelimiterIndex;
+  UINT8   OriginalDelimiter;
+  UINT32  DelimiterIndex;
 
   // Replace the ; or ? with a terminator;
   for (DelimiterIndex = 0; DelimiterIndex < CommandLength; DelimiterIndex++) {


### PR DESCRIPTION
## Description

Fix potential index overflow in GDB parsing.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
