### PR TITLE
Add workaround for windbg trying to read windows shared data page

### DIFF
--- a/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStub.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStub.c
@@ -403,8 +403,13 @@ ProcessMemoryCommand (
         return;
       }
     } else {
-      // Workaround for debugger issue.
-      if ((Address == 0) && (RangeLength < EFI_PAGE_SIZE)) {
+      //
+      // WORK AROUND: Windbg will try to read page 0 and the Windows Shared Data
+      // page, but will loop for quite some time if those do not succeed. Just
+      // return 0 so that the logic fails fast.
+      //
+
+      if (((Address == 0) || ((Address & ~EFI_PAGE_MASK) == 0xfffff78000000000llu)) && (RangeLength < EFI_PAGE_SIZE)) {
         ZeroMem (&mScratch[0], RangeLength);
       } else if (!DbgReadMemory (Address, &mScratch[0], RangeLength)) {
         SendGdbError (GDB_ERROR_BAD_MEM_ADDRESS);


### PR DESCRIPTION
## Description

Windbg tries to read the Windows shared data page as some sort of heuristic when connecting. Because this page does not exist in UEFI mappings, Windows may loop on this read so long as it fails. This work around will just return 0 when reads occur to this well-known VA so cause the heuristic to fail fast.  

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Q35 virtual platform.

## Integration Instructions

N/A
