### PR TITLE
Improvements to Windbgx integration and UEFI extension

### DIFF
--- a/DebuggerFeaturePkg/DebuggerFeaturePkg.dec
+++ b/DebuggerFeaturePkg/DebuggerFeaturePkg.dec
@@ -54,3 +54,7 @@
   ## Forcibly enables the debugger with a default configuration depending on the
   #  phase implementation.
   DebuggerFeaturePkgTokenSpaceGuid.PcdForceEnableDebugger|FALSE|BOOLEAN|0x00000003
+
+  ## Enabled work-arounds in the debugger for bugs in windbg's GDB implementation.
+  #  This should not break GDB debuggers, but may cause slightly unexpected behavior.
+  DebuggerFeaturePkgTokenSpaceGuid.PcdEnableWindbgWorkarounds|TRUE|BOOLEAN|0x00000004

--- a/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/DebugAarch64.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/DebugAarch64.c
@@ -158,6 +158,18 @@ DebuggerExceptionHandler (
 
   ExceptionInfo.ArchExceptionCode = ExceptionType;
 
+  if (PcdGetBool (PcdEnableWindbgWorkarounds) &&
+      (ExceptionType == 0x3c) &&
+      (DebuggerBreakpointReason != BreakpointReasonNone) &&
+      (CompareMem ((UINT8 *)Context->ELR, &ArchBreakpointInstruction[0], ArchBreakpointInstructionSize) == 0))
+  {
+    //
+    // Windbg will act oddly when broken in on a actual INT 3 instruction, so
+    // preemptively step past this.
+    //
+    Context->ELR += ArchBreakpointInstructionSize;
+  }
+
   ReportEntryToDebugger (&ExceptionInfo, SystemContext);
 
   //

--- a/DebuggerFeaturePkg/Library/DebugAgent/Breakpoint.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/Breakpoint.c
@@ -25,6 +25,8 @@ typedef struct _BREAKPOINT_INFO {
 
 BREAKPOINT_INFO  mBreakpoints[MAX_BREAKPOINTS];
 
+BREAKPOINT_REASON  DebuggerBreakpointReason = BreakpointReasonNone;
+
 /**
   Adds a software breakpoint as the specific address.
 
@@ -95,4 +97,20 @@ RemoveSoftwareBreakpoint (
 
   // Not found.
   return FALSE;
+}
+
+/**
+  Immediately breaks into the debugger.
+
+  @param[in]  Reason    The reason for the debug break.
+
+**/
+VOID
+DebuggerBreak (
+  BREAKPOINT_REASON  Reason
+  )
+{
+  DebuggerBreakpointReason = Reason;
+  CpuBreakpoint ();
+  DebuggerBreakpointReason = BreakpointReasonNone;
 }

--- a/DebuggerFeaturePkg/Library/DebugAgent/DebugAgent.h
+++ b/DebuggerFeaturePkg/Library/DebugAgent/DebugAgent.h
@@ -78,6 +78,7 @@ typedef enum _BREAKPOINT_REASON {
   BreakpointReasonNone = 0,
   BreakpointReasonInitial,
   BreakpointReasonModuleLoad,
+  BreakpointReasonDebuggerBreak,
 } BREAKPOINT_REASON;
 
 extern BREAKPOINT_REASON  DebuggerBreakpointReason;
@@ -176,6 +177,11 @@ AddSoftwareBreakpoint (
 BOOLEAN
 RemoveSoftwareBreakpoint (
   UINTN  Address
+  );
+
+VOID
+DebuggerBreak (
+  BREAKPOINT_REASON  Reason
   );
 
 //

--- a/DebuggerFeaturePkg/Library/DebugAgent/DebugAgent.h
+++ b/DebuggerFeaturePkg/Library/DebugAgent/DebugAgent.h
@@ -80,7 +80,7 @@ typedef enum _BREAKPOINT_REASON {
   BreakpointReasonModuleLoad,
 } BREAKPOINT_REASON;
 
-BREAKPOINT_REASON  DebuggerBreakpointReason = BreakpointReasonNone;
+extern BREAKPOINT_REASON  DebuggerBreakpointReason;
 
 //
 // Global used for debugger information.

--- a/DebuggerFeaturePkg/Library/DebugAgent/DebugAgent.h
+++ b/DebuggerFeaturePkg/Library/DebugAgent/DebugAgent.h
@@ -71,10 +71,16 @@ extern UINTN   ArchBreakpointInstructionSize;
 extern UINT32  ArchExceptionTypes[];
 
 //
-// Global used for early use of performance counter
+// Global used to track debugger invoked breakpoint.
 //
 
-extern UINT64  gPerformanceCounterFreq;
+typedef enum _BREAKPOINT_REASON {
+  BreakpointReasonNone = 0,
+  BreakpointReasonInitial,
+  BreakpointReasonModuleLoad,
+} BREAKPOINT_REASON;
+
+BREAKPOINT_REASON  DebuggerBreakpointReason = BreakpointReasonNone;
 
 //
 // Global used for debugger information.

--- a/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.c
@@ -44,6 +44,8 @@ CHAR8  DbgLogBuffer[DBG_LOG_SIZE];
 UINTN  DbgLogOffset = 0;
 #endif
 
+BREAKPOINT_REASON  DebuggerBreakpointReason = BreakpointReasonNone;
+
 DEBUGGER_CONTROL_HOB  DefaultDebugConfig = {
   .Control.AsUint32 = 0x3,
   0x300000, // Reasonable guess, timing may be inaccurate.

--- a/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.c
@@ -328,7 +328,10 @@ OnLoadedImageNotification (
 
     if (AsciiStrLen (Name) == AsciiStrLen (mDbgBreakOnModuleLoadString)) {
       if (AsciiStriCmp (mDbgBreakOnModuleLoadString, Name) == 0) {
+        DebuggerBreakpointReason = BreakpointReasonModuleLoad;
         CpuBreakpoint ();
+        DebuggerBreakpointReason = BreakpointReasonNone;
+
         mDbgBreakOnModuleLoadString[0] = 0;
         break;
       }

--- a/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.c
@@ -44,8 +44,6 @@ CHAR8  DbgLogBuffer[DBG_LOG_SIZE];
 UINTN  DbgLogOffset = 0;
 #endif
 
-BREAKPOINT_REASON  DebuggerBreakpointReason = BreakpointReasonNone;
-
 DEBUGGER_CONTROL_HOB  DefaultDebugConfig = {
   .Control.AsUint32 = 0x3,
   0x300000, // Reasonable guess, timing may be inaccurate.
@@ -330,10 +328,7 @@ OnLoadedImageNotification (
 
     if (AsciiStrLen (Name) == AsciiStrLen (mDbgBreakOnModuleLoadString)) {
       if (AsciiStriCmp (mDbgBreakOnModuleLoadString, Name) == 0) {
-        DebuggerBreakpointReason = BreakpointReasonModuleLoad;
-        CpuBreakpoint ();
-        DebuggerBreakpointReason = BreakpointReasonNone;
-
+        DebuggerBreak (BreakpointReasonModuleLoad);
         mDbgBreakOnModuleLoadString[0] = 0;
         break;
       }

--- a/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.inf
+++ b/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.inf
@@ -79,6 +79,7 @@
 
 [Pcd.common]
   DebuggerFeaturePkgTokenSpaceGuid.PcdForceEnableDebugger           ## CONSUMES
+  DebuggerFeaturePkgTokenSpaceGuid.PcdEnableWindbgWorkarounds       ## CONSUMES
 
 [BuildOptions]
   *_*_*_CC_FLAGS  = -D BUILDING_IN_UEFI

--- a/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentMm.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentMm.c
@@ -36,8 +36,6 @@ CHAR8  DbgLogBuffer[DBG_LOG_SIZE];
 UINTN  DbgLogOffset = 0;
 #endif
 
-BREAKPOINT_REASON  DebuggerBreakpointReason = BreakpointReasonNone;
-
 //
 // MM externs. Because of the flat nature of MM, this must be statically linked
 // and is not yet part of a library.

--- a/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentMm.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentMm.c
@@ -36,6 +36,8 @@ CHAR8  DbgLogBuffer[DBG_LOG_SIZE];
 UINTN  DbgLogOffset = 0;
 #endif
 
+BREAKPOINT_REASON  DebuggerBreakpointReason = BreakpointReasonNone;
+
 //
 // MM externs. Because of the flat nature of MM, this must be statically linked
 // and is not yet part of a library.

--- a/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentMm.inf
+++ b/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentMm.inf
@@ -74,6 +74,7 @@
 
 [Pcd.common]
   DebuggerFeaturePkgTokenSpaceGuid.PcdForceEnableDebugger           ## CONSUMES
+  DebuggerFeaturePkgTokenSpaceGuid.PcdEnableWindbgWorkarounds       ## CONSUMES
 
 [BuildOptions]
   *_*_*_CC_FLAGS  = -D BUILDING_IN_UEFI

--- a/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStub.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStub.c
@@ -1123,7 +1123,7 @@ DebuggerPollInput (
 
     // Check for the break character CTRL-C.
     if (Character == 0x3) {
-      CpuBreakpoint ();
+      DebuggerBreak (BreakpointReasonDebuggerBreak);
     }
   }
 }
@@ -1140,10 +1140,8 @@ DebuggerInitialBreakpoint (
   UINT64  Timeout
   )
 {
-  mNextBreakpointTimeout   = Timeout;
-  DebuggerBreakpointReason = BreakpointReasonInitial;
-  CpuBreakpoint ();
-  DebuggerBreakpointReason = BreakpointReasonNone;
+  mNextBreakpointTimeout = Timeout;
+  DebuggerBreak (BreakpointReasonInitial);
 }
 
 /**

--- a/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStub.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStub.c
@@ -409,7 +409,10 @@ ProcessMemoryCommand (
       // return 0 so that the logic fails fast.
       //
 
-      if (((Address == 0) || ((Address & ~EFI_PAGE_MASK) == 0xfffff78000000000llu)) && (RangeLength < EFI_PAGE_SIZE)) {
+      if (PcdGetBool (PcdEnableWindbgWorkarounds) &&
+          ((Address == 0) || ((Address & ~EFI_PAGE_MASK) == 0xfffff78000000000llu)) &&
+          (RangeLength < EFI_PAGE_SIZE))
+      {
         ZeroMem (&mScratch[0], RangeLength);
       } else if (!DbgReadMemory (Address, &mScratch[0], RangeLength)) {
         SendGdbError (GDB_ERROR_BAD_MEM_ADDRESS);
@@ -1137,8 +1140,10 @@ DebuggerInitialBreakpoint (
   UINT64  Timeout
   )
 {
-  mNextBreakpointTimeout = Timeout;
+  mNextBreakpointTimeout   = Timeout;
+  DebuggerBreakpointReason = BreakpointReasonInitial;
   CpuBreakpoint ();
+  DebuggerBreakpointReason = BreakpointReasonNone;
 }
 
 /**

--- a/DebuggerFeaturePkg/Library/DebugAgent/X64/DebugX64.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/X64/DebugX64.c
@@ -112,12 +112,17 @@ DebuggerExceptionHandler (
 
   ExceptionInfo.ArchExceptionCode = InterruptType;
 
-  if (PcdGetBool (PcdForceEnableDebugger) && (InterruptType == EXCEPT_X64_BREAKPOINT)) {
+  if (PcdGetBool (PcdEnableWindbgWorkarounds) &&
+      (InterruptType == EXCEPT_X64_BREAKPOINT) &&
+      (DebuggerBreakpointReason != BreakpointReasonNone) &&
+      (*((UINT8 *)Context->Rip) == 0xCC))
+  {
+    //
     // Windbg will act oddly when broken in on a actual INT 3 instruction, so
-    // pre-emptively step past this.
-    if (*((UINT8 *)Context->Rip) == 0xCC) {
-      Context->Rip++;
-    }
+    // preemptively step past this.
+    //
+
+    Context->Rip++;
   }
 
   // Call into the core debugger module.

--- a/DebuggerFeaturePkg/Library/DebugAgent/X64/DebugX64.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/X64/DebugX64.c
@@ -112,6 +112,14 @@ DebuggerExceptionHandler (
 
   ExceptionInfo.ArchExceptionCode = InterruptType;
 
+  if (PcdGetBool (PcdForceEnableDebugger) && (InterruptType == EXCEPT_X64_BREAKPOINT)) {
+    // Windbg will act oddly when broken in on a actual INT 3 instruction, so
+    // pre-emptively step past this.
+    if (*((UINT8 *)Context->Rip) == 0xCC) {
+      Context->Rip++;
+    }
+  }
+
   // Call into the core debugger module.
   ReportEntryToDebugger (&ExceptionInfo, SystemContext);
 

--- a/DebuggerFeaturePkg/Readme.md
+++ b/DebuggerFeaturePkg/Readme.md
@@ -90,7 +90,8 @@ for more information.
 You can attach to the UEFI debugger from the windbgx UI. Press Ctrl-K to get to
 the kernel debugger options, and click on the EXDI tab. From there you can can select
 the UEFI option, the appropriate architecture, Windows (not used), "None" for
-Image scanning heuristics size, and select the correct IP and port.
+Image scanning heuristics size, and select the correct IP and port. This requires
+Windbgx version 1.2404.22002.0 or newer.
 
 ![Windbgx EXDI UEFI](./Docs/Images/windbgx_uefi.png)
 

--- a/UefiDbgExt/memory.cpp
+++ b/UefiDbgExt/memory.cpp
@@ -245,7 +245,6 @@ advlog (
   ULONG                             Offset;
   ULONG                             End;
   ADVANCED_LOGGER_MESSAGE_ENTRY_V2  *Entry;
-  CHAR                              Temp;
 
   // NOTE: This implementation is a crude first past, The following should be done
   // in the future.
@@ -293,7 +292,6 @@ advlog (
 
   dprintf ("Version:  %d\n", Version);
   dprintf ("Size:     0x%x bytes\n", LogBufferSize);
-  dprintf ("\n------------------------------------------------------------------------------\n");
 
   if (LogBufferSize == 0) {
     dprintf ("Bad log buffer size!\n");
@@ -327,6 +325,7 @@ advlog (
     Offset = (ULONG)(EntryAddress - InfoAddress);
     End    = (ULONG)(EndAddress - InfoAddress);
 
+    dprintf ("\n------------------------------------------------------------------------------\n");
     while (Offset < End) {
       Entry = (ADVANCED_LOGGER_MESSAGE_ENTRY_V2 *)(LogBuffer + Offset);
       if (Entry->Signature != 0x324d4c41) {
@@ -334,19 +333,19 @@ advlog (
         break;
       }
 
-      Temp = LogBuffer[Offset+Entry->MessageOffset+Entry->MessageLen];
-
-      LogBuffer[Offset+Entry->MessageOffset+Entry->MessageLen] = 0;
+      ULONG  StringEnd = Offset + Entry->MessageOffset + Entry->MessageLen;
+      CHAR   Temp      = LogBuffer[StringEnd];
+      LogBuffer[StringEnd] = 0;
       dprintf ("%s", LogBuffer + Offset + Entry->MessageOffset);
-      LogBuffer[Offset+Entry->MessageOffset+Entry->MessageLen] = Temp;
+      LogBuffer[StringEnd] = Temp;
 
       Offset = ALIGN_UP (Offset + Entry->MessageOffset + Entry->MessageLen, 8);
     }
+
+    dprintf ("\n------------------------------------------------------------------------------\n");
   } else {
     dprintf ("\nVersion not implemented in debug extension!\n");
   }
-
-  dprintf ("\n------------------------------------------------------------------------------\n");
 
   Result = S_OK;
 

--- a/UefiDbgExt/swdebug.cpp
+++ b/UefiDbgExt/swdebug.cpp
@@ -69,7 +69,7 @@ readmsr (
     dprintf ("Must provide MSR index in HEX!");
   }
 
-  sprintf_s (Command, sizeof (Command), ".exdicmd target:0:\"m%s\"", args);
+  sprintf_s (Command, sizeof (Command), ".exdicmd target:0:m%s", args);
   g_ExtControl->Execute (
                   DEBUG_OUTCTL_ALL_CLIENTS,
                   Command,
@@ -94,7 +94,7 @@ readvar (
     dprintf ("Must provide variable name!");
   }
 
-  sprintf_s (Command, sizeof (Command), ".exdicmd target:*:\"v%s\"", args);
+  sprintf_s (Command, sizeof (Command), ".exdicmd target:*:v%s", args);
   g_ExtControl->Execute (
                   DEBUG_OUTCTL_ALL_CLIENTS,
                   Command,

--- a/UefiDbgExt/swdebug.cpp
+++ b/UefiDbgExt/swdebug.cpp
@@ -17,6 +17,24 @@ Abstract:
 #include "uefiext.h"
 
 HRESULT CALLBACK
+info (
+  PDEBUG_CLIENT4  Client,
+  PCSTR           args
+  )
+{
+  INIT_API ();
+
+  g_ExtControl->Execute (
+                  DEBUG_OUTCTL_ALL_CLIENTS,
+                  ".exdicmd target:0:?",
+                  DEBUG_EXECUTE_DEFAULT
+                  );
+
+  EXIT_API ();
+  return S_OK;
+}
+
+HRESULT CALLBACK
 modulebreak (
   PDEBUG_CLIENT4  Client,
   PCSTR           args

--- a/UefiDbgExt/uefiext.cpp
+++ b/UefiDbgExt/uefiext.cpp
@@ -64,19 +64,27 @@ help (
 
   dprintf (
     "Help for uefiext.dll\n"
+    "\nBasic Commands:\n"
     "  help                - Shows this help\n"
     "  init                - Detects and initializes windbg for debugging UEFI.\n"
+    "  setenv              - Set the extensions environment mode\n"
+    "\nModule Discovery:\n"
     "  findall             - Attempts to detect environment and load all modules\n"
     "  findmodule          - Find the currently running module\n"
-    "  memorymap           - Prints the current memory map\n"
     "  loadmodules         - Find and loads symbols for all modules in the debug list\n"
-    "  setenv              - Set the extensions environment mode\n"
+    "\nData Parsing:\n"
+    "  memorymap           - Prints the current memory map\n"
     "  hobs                - Enumerates the hand off blocks\n"
-    "  modulebreak         - Sets a break on load for the provided module. e.g. 'shell'\n"
     "  protocols           - Lists the protocols from the protocol list.\n"
     "  handles             - Prints the handles list.\n"
     "  linkedlist          - Parses a UEFI style linked list of entries.\n"
     "  efierror            - Translates an EFI error code.\n"
+    "  advlog              - Prints the advanced logger memory log.\n"
+    "\nUEFI Debugger:\n"
+    "  info                - Queries information about the UEFI debugger\n"
+    "  modulebreak         - Sets a break on load for the provided module. e.g. 'shell'\n"
+    "  readmsr             - Reads a MSR value (x86 only)\n"
+    "  readvar             - reads a UEFI variable\n"
     );
 
   EXIT_API ();

--- a/UefiDbgExt/uefiext.cpp
+++ b/UefiDbgExt/uefiext.cpp
@@ -92,6 +92,7 @@ init (
 {
   ULONG  TargetClass = 0;
   ULONG  TargetQual  = 0;
+  ULONG  Mask;
 
   INIT_API ();
 
@@ -100,6 +101,11 @@ init (
   dprintf ("Initializing UEFI Debugger Extension\n");
   g_ExtControl->GetDebuggeeType (&TargetClass, &TargetQual);
   if ((TargetClass == DEBUG_CLASS_KERNEL) && (TargetQual == DEBUG_KERNEL_EXDI_DRIVER)) {
+    // Enabled the verbose flag in the output mask. This is required for .exdicmd
+    // output.
+    Client->GetOutputMask (&Mask);
+    Client->SetOutputMask (Mask | DEBUG_OUTPUT_VERBOSE);
+
     dprintf ("EXDI Connection, scanning for images.\n");
     g_ExtControl->Execute (
                     DEBUG_OUTCTL_ALL_CLIENTS,

--- a/UefiDbgExt/uefiext.def
+++ b/UefiDbgExt/uefiext.def
@@ -11,21 +11,23 @@ EXPORTS
 ;--------------------------------------------------------------------
 ; These are the extensions exported by dll
 ;--------------------------------------------------------------------
-    help
-    memorymap
-    findmodule
-    loadmodules
+    advlog
+    efierror
     findall
-    setenv
+    findmodule
+    handles
+    help
     hobs
+    info
+    init
+    linkedlist
+    loadmodules
+    memorymap
     modulebreak
+    protocols
     readmsr
     readvar
-    protocols
-    handles
-    linkedlist
-    efierror
-    init
+    setenv
 
 ;--------------------------------------------------------------------
 ;

--- a/UefiDbgExt/uefiext.h
+++ b/UefiDbgExt/uefiext.h
@@ -23,6 +23,9 @@ Abstract:
 #define PAGE_SIZE  (0x1000)
 #define PAGE_ALIGN_DOWN(_ptr)  (_ptr & ~(PAGE_SIZE - 1))
 
+#define ALIGN_UP(address, alignment) \
+    (((address + alignment - 1) / alignment) * alignment)
+
 //
 // EFI environment information.
 //


### PR DESCRIPTION
## Description

Improvements to the core for:
1. Add windbg workaround PCD to allow disabling for native GDB systems.
2. Add break reason for debugger initiated breakpoints
3. Add workaround for #10 
4. Fix `.reboot` not working

Improvements to UEFI Extension:
1. Cleaned up help function
2. Added crude implementation for adv logger parser 


- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

Local tests on QEMU

## Integration Instructions

N/A
