### PR TITLE
Improvements to UEFIExt and fix register writes

### DIFF
--- a/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.c
@@ -330,7 +330,6 @@ OnLoadedImageNotification (
     if (AsciiStrLen (Name) == AsciiStrLen (mDbgBreakOnModuleLoadString)) {
       if (AsciiStriCmp (mDbgBreakOnModuleLoadString, Name) == 0) {
         DebuggerBreak (BreakpointReasonModuleLoad);
-        mDbgBreakOnModuleLoadString[0] = 0;
         break;
       }
     }

--- a/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStub.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStub.c
@@ -705,26 +705,28 @@ WriteRegisterToContext (
   )
 {
   UINT8  *RegPtr;
-  UINT8  OrigChar;
-  UINTN  Value;
-  UINTN  StrLen;
+  UINT8  Value[10];
+  UINTN  Index;
+
+  ASSERT (gRegisterOffsets[RegNumber].Size <= sizeof (Value));
 
   // Two characters for every byte.
-  StrLen = gRegisterOffsets[RegNumber].Size * 2;
-  if (AsciiStrLen (Input) < StrLen) {
+  if (AsciiStrLen (Input) < gRegisterOffsets[RegNumber].Size * 2) {
     return NULL;
   }
 
   if (gRegisterOffsets[RegNumber].Offset != REG_NOT_PRESENT) {
-    RegPtr        = Registers + gRegisterOffsets[RegNumber].Offset;
-    OrigChar      = Input[StrLen];
-    Input[StrLen] = 0;
-    Value         = AsciiStrHexToUintn (Input);
-    Input[StrLen] = OrigChar;
-    CopyMem (RegPtr, &Value, gRegisterOffsets[RegNumber].Size);
+    RegPtr = Registers + gRegisterOffsets[RegNumber].Offset;
+    ZeroMem (&Value[0], sizeof (Value));
+    for (Index = 0; Index < gRegisterOffsets[RegNumber].Size; Index += 1) {
+      Value[Index] = HexToByte (Input);
+      Input       += 2;
+    }
+
+    CopyMem (RegPtr, &Value[0], gRegisterOffsets[RegNumber].Size);
   }
 
-  return Input + StrLen;
+  return Input;
 }
 
 /**

--- a/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStub.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStub.c
@@ -47,9 +47,10 @@ STATIC CONST CHAR8  *EXCEPTION_TYPE_STRINGS[] = {
 // Current state
 //
 
-EFI_SYSTEM_CONTEXT  *gSystemContext = NULL;
-EXCEPTION_INFO      *gExceptionInfo = NULL;
-BOOLEAN             gRunning        = TRUE;
+EFI_SYSTEM_CONTEXT  *gSystemContext   = NULL;
+EXCEPTION_INFO      *gExceptionInfo   = NULL;
+BOOLEAN             gRunning          = TRUE;
+BOOLEAN             mRebootOnContinue = FALSE;
 
 //
 // Buffers for GDB packets. Memory allocation are not available at first, so these
@@ -510,6 +511,11 @@ ProcessMonitorCmd (
 
     case 'M': // MSR Write
       AsciiSPrint (&mScratch[0], SCRATCH_SIZE, "TODO\n\r");
+      break;
+
+    case 'R': // Set Reboot on Continue
+      mRebootOnContinue = TRUE;
+      AsciiSPrint (&mScratch[0], SCRATCH_SIZE, "Will reboot on continue.\n\r");
       break;
 
     case 'b': // Module Break
@@ -1191,6 +1197,10 @@ ReportEntryToDebugger (
     if (!mConnectionOccurred && (EndTime != 0) && (DebugGetTimeMs () >= EndTime)) {
       gRunning = TRUE;
     }
+  }
+
+  if (mRebootOnContinue) {
+    DebugReboot ();
   }
 
   // Re-enable logging prints.

--- a/Scripts/exdiConfigData.xml
+++ b/Scripts/exdiConfigData.xml
@@ -83,6 +83,24 @@
         <Entry Name ="cr3" Order = "1a" Size ="8" />
         <Entry Name ="cr4" Order = "1b" Size ="8" />
         <Entry Name ="cr8" Order = "1c" Size ="8" />
+
+        <Entry Name ="fctrl" Order = "1d" Size ="4" />
+        <Entry Name ="fstat" Order = "1e" Size ="4" />
+        <Entry Name ="ftag" Order = "1f" Size ="4" />
+        <Entry Name ="fiseg" Order = "20" Size ="4" />
+        <Entry Name ="fioff" Order = "21" Size ="4" />
+        <Entry Name ="foseg" Order = "22" Size ="4" />
+        <Entry Name ="fooff" Order = "23" Size ="4" />
+        <Entry Name ="fop" Order = "24" Size ="10" />
+        <Entry Name ="st0" Order = "25" Size ="10" />
+        <Entry Name ="st1" Order = "26" Size ="10" />
+        <Entry Name ="st2" Order = "27" Size ="10" />
+        <Entry Name ="st3" Order = "28" Size ="10" />
+        <Entry Name ="st4" Order = "29" Size ="10" />
+        <Entry Name ="st5" Order = "2a" Size ="10" />
+        <Entry Name ="st6" Order = "2b" Size ="10" />
+        <Entry Name ="st7" Order = "2c" Size ="10" />
+
       </ExdiGdbServerRegisters>
     </ExdiGdbServerConfigData>
   </ExdiTarget>

--- a/UefiDbgExt/efiutil.cpp
+++ b/UefiDbgExt/efiutil.cpp
@@ -52,6 +52,59 @@ GetNextListEntry (
   return (LinkAddress - LinkOffset);
 }
 
+PCSTR
+ErrorLevelToString (
+  UINT32  ErrorLevel
+  )
+{
+  switch (ErrorLevel) {
+    case 0x00000001:
+      return "INIT";
+    case 0x00000002:
+      return "WARN";
+    case 0x00000004:
+      return "LOAD";
+    case 0x00000008:
+      return "FS";
+    case 0x00000010:
+      return "POOL";
+    case 0x00000020:
+      return "PAGE";
+    case 0x00000040:
+      return "INFO";
+    case 0x00000080:
+      return "DISPATCH";
+    case 0x00000100:
+      return "VARIABLE";
+    case 0x00000200:
+      return "SMI";
+    case 0x00000400:
+      return "BM";
+    case 0x00001000:
+      return "BLKIO";
+    case 0x00004000:
+      return "NET";
+    case 0x00010000:
+      return "UNDI";
+    case 0x00020000:
+      return "LDFILE";
+    case 0x00080000:
+      return "EVENT";
+    case 0x00100000:
+      return "GCD";
+    case 0x00200000:
+      return "CACHE";
+    case 0x00400000:
+      return "VERBOSE";
+    case 0x00800000:
+      return "MANAGEABILITY";
+    case 0x80000000:
+      return "ERROR";
+    default:
+      return "UNK";
+  }
+}
+
 PCHAR
 GuidToString (
   GUID  *Guid

--- a/UefiDbgExt/memory.cpp
+++ b/UefiDbgExt/memory.cpp
@@ -357,7 +357,7 @@ advlog (
 
       if (PrevNL) {
         dprintf (
-          "%-8s- %-8s| ",
+          "%-8s| %-8s| ",
           (Entry->Phase < PHASE_COUNT ? PhaseStrings[Entry->Phase] : "UNK"),
           ErrorLevelToString (Entry->DebugLevel)
           );

--- a/UefiDbgExt/memory.cpp
+++ b/UefiDbgExt/memory.cpp
@@ -20,6 +20,21 @@ Abstract:
 // **************************************************************  Definitions
 //
 
+#pragma pack (push, 1)
+typedef struct {
+  UINT32    Signature;          // Signature
+  UINT8     MajorVersion;       // Major version of advanced logger message structure
+  UINT8     MinorVersion;       // Minor version of advanced logger message structure
+  UINT32    DebugLevel;         // Debug Level
+  UINT64    TimeStamp;          // Time stamp
+  UINT16    Phase;              // Boot phase that produced this message entry
+  UINT16    MessageLen;         // Number of bytes in Message
+  UINT16    MessageOffset;      // Offset of Message from start of structure,
+                                // used to calculate the address of the Message
+  // CHAR      MessageText[];      // Message Text
+} ADVANCED_LOGGER_MESSAGE_ENTRY_V2;
+#pragma pack (pop)
+
 PCSTR  MemoryTypeString[] = {
   "EfiReservedMemoryType",
   "EfiLoaderCode",
@@ -57,6 +72,23 @@ PSTR  HobTypes[] = {
 };
 
 #define HOB_TYPE_COUNT  (sizeof(HobTypes) / sizeof(HobTypes[0]))
+
+PCSTR  PhaseStrings[] = {
+  "UNSPEC",
+  "SEC",
+  "PEI",
+  "PEI64",
+  "DXE",
+  "RT",
+  "MmCore",
+  "MM",
+  "SmmCore",
+  "SMM",
+  "TFA",
+  "CNT",
+};
+
+#define PHASE_COUNT  (sizeof(PhaseStrings) / sizeof(PhaseStrings[0]))
 
 //
 // *******************************************************  External Functions
@@ -213,21 +245,6 @@ hobs (
   return S_OK;
 }
 
-#pragma pack (push, 1)
-typedef struct {
-  UINT32    Signature;          // Signature
-  UINT8     MajorVersion;       // Major version of advanced logger message structure
-  UINT8     MinorVersion;       // Minor version of advanced logger message structure
-  UINT32    DebugLevel;         // Debug Level
-  UINT64    TimeStamp;          // Time stamp
-  UINT16    Phase;              // Boot phase that produced this message entry
-  UINT16    MessageLen;         // Number of bytes in Message
-  UINT16    MessageOffset;      // Offset of Message from start of structure,
-                                // used to calculate the address of the Message
-  // CHAR      MessageText[];      // Message Text
-} ADVANCED_LOGGER_MESSAGE_ENTRY_V2;
-#pragma pack (pop)
-
 HRESULT CALLBACK
 advlog (
   PDEBUG_CLIENT4  Client,
@@ -326,6 +343,7 @@ advlog (
     End    = (ULONG)(EndAddress - InfoAddress);
 
     dprintf ("\n------------------------------------------------------------------------------\n");
+    BOOLEAN  PrevNL = TRUE;
     while (Offset < End) {
       Entry = (ADVANCED_LOGGER_MESSAGE_ENTRY_V2 *)(LogBuffer + Offset);
       if (Entry->Signature != 0x324d4c41) {
@@ -336,7 +354,18 @@ advlog (
       ULONG  StringEnd = Offset + Entry->MessageOffset + Entry->MessageLen;
       CHAR   Temp      = LogBuffer[StringEnd];
       LogBuffer[StringEnd] = 0;
+
+      if (PrevNL) {
+        dprintf (
+          "%-8s- %-8s| ",
+          (Entry->Phase < PHASE_COUNT ? PhaseStrings[Entry->Phase] : "UNK"),
+          ErrorLevelToString (Entry->DebugLevel)
+          );
+      }
+
       dprintf ("%s", LogBuffer + Offset + Entry->MessageOffset);
+      PrevNL = (LogBuffer[StringEnd - 1] == '\n');
+
       LogBuffer[StringEnd] = Temp;
 
       Offset = ALIGN_UP (Offset + Entry->MessageOffset + Entry->MessageLen, 8);

--- a/UefiDbgExt/swdebug.cpp
+++ b/UefiDbgExt/swdebug.cpp
@@ -94,10 +94,37 @@ readvar (
     dprintf ("Must provide variable name!");
   }
 
-  sprintf_s (Command, sizeof (Command), ".exdicmd target:*:v%s", args);
+  sprintf_s (Command, sizeof (Command), ".exdicmd target:0:v%s", args);
   g_ExtControl->Execute (
                   DEBUG_OUTCTL_ALL_CLIENTS,
                   Command,
+                  DEBUG_EXECUTE_DEFAULT
+                  );
+
+  EXIT_API ();
+  return S_OK;
+}
+
+HRESULT CALLBACK
+reboot (
+  PDEBUG_CLIENT4  Client,
+  PCSTR           args
+  )
+{
+  INIT_API ();
+
+  // Set reboot on continue
+  g_ExtControl->Execute (
+                  DEBUG_OUTCTL_ALL_CLIENTS,
+                  ".exdicmd target:0:R",
+                  DEBUG_EXECUTE_DEFAULT
+                  );
+
+  // Continue, this will reboot the system.
+  dprintf ("\nRebooting...\n");
+  g_ExtControl->Execute (
+                  DEBUG_OUTCTL_ALL_CLIENTS,
+                  "g",
                   DEBUG_EXECUTE_DEFAULT
                   );
 

--- a/UefiDbgExt/swdebug.cpp
+++ b/UefiDbgExt/swdebug.cpp
@@ -120,6 +120,13 @@ reboot (
                   DEBUG_EXECUTE_DEFAULT
                   );
 
+  // Clear the symbols since the modules will be unloaded across reset.
+  g_ExtControl->Execute (
+                  DEBUG_OUTCTL_ALL_CLIENTS,
+                  ".reload /u",
+                  DEBUG_EXECUTE_DEFAULT
+                  );
+
   // Continue, this will reboot the system.
   dprintf ("\nRebooting...\n");
   g_ExtControl->Execute (

--- a/UefiDbgExt/uefiext.cpp
+++ b/UefiDbgExt/uefiext.cpp
@@ -84,7 +84,8 @@ help (
     "  info                - Queries information about the UEFI debugger\n"
     "  modulebreak         - Sets a break on load for the provided module. e.g. 'shell'\n"
     "  readmsr             - Reads a MSR value (x86 only)\n"
-    "  readvar             - reads a UEFI variable\n"
+    "  readvar             - Reads a UEFI variable\n"
+    "  reboot              - Reboots the system\n"
     );
 
   EXIT_API ();

--- a/UefiDbgExt/uefiext.def
+++ b/UefiDbgExt/uefiext.def
@@ -27,6 +27,7 @@ EXPORTS
     protocols
     readmsr
     readvar
+    reboot
     setenv
 
 ;--------------------------------------------------------------------

--- a/UefiDbgExt/uefiext.h
+++ b/UefiDbgExt/uefiext.h
@@ -70,3 +70,8 @@ PCHAR
 GuidToString (
   GUID  *Guid
   );
+
+PCSTR
+ErrorLevelToString (
+  UINT32  ErrorLevel
+  );

--- a/UefiDbgExt/uefiext.h
+++ b/UefiDbgExt/uefiext.h
@@ -66,6 +66,12 @@ GetNextListEntry (
   IN UINT64   Previous
   );
 
+ULONG
+TokenizeArgs (
+  PCSTR  args,
+  PSTR   **Tokens
+  );
+
 PCHAR
 GuidToString (
   GUID  *Guid


### PR DESCRIPTION
## Description

1. Fix issue with setting registers. This requires a windbgx fix as well. 
      - https://github.com/microsoft/WinDbg-Samples/pull/108
3. Add `!reboot` command for better reboot experience
4. Fixes setting `!modulebreak` after an existing modulebreak
5. fix full load of module on iterative runs of `!findall`
6. improvements to `!advlog`





- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested with Q35 & SBSA

## Integration Instructions

N/A
