### PR TITLE
Fix single step on AARCH64 processors

### DIFF
--- a/DebuggerFeaturePkg/DebuggerFeaturePkg.ci.yaml
+++ b/DebuggerFeaturePkg/DebuggerFeaturePkg.ci.yaml
@@ -73,7 +73,9 @@
             "fioff",
             "fiseg",
             "fooff",
-            "foseg"],
+            "foseg",
+            "oslar",
+            "oslsr"],
         "IgnoreStandardPaths": [],   # Standard Plugin defined paths that should be ignore
         "AdditionalIncludePaths": [] # Additional paths to spell check (wildcards supported)
     },

--- a/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/DebugAarch64.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/DebugAarch64.c
@@ -61,7 +61,7 @@ DebugReadOslsrEl1 (
   );
 
 VOID
-DebugWriteOslsrEl1 (
+DebugWriteOslarEl1 (
   IN UINT64  Value
   );
 
@@ -285,11 +285,11 @@ DebugArchInit (
   SpeculationBarrier();
 
   // Clear the OS lock.
-  // Value = DebugReadOslsrEl1();
-  // if (Value & OSLSR_LOCKED) {
-  //   DebugWriteOslsrEl1(0);
-  // }
-  // SpeculationBarrier();
+  Value = DebugReadOslsrEl1();
+  if (Value & OSLSR_LOCKED) {
+    DebugWriteOslarEl1(0);
+  }
+  SpeculationBarrier();
 
   // Enable kernel and monitor debug bits.
   Value  = DebugReadMdscrEl1 ();

--- a/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/DebugAarch64.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/DebugAarch64.c
@@ -27,9 +27,9 @@
 #define MDSCR_TDCC  0x00001000
 #define MDSCR_SS    0x00000001
 
-#define OSLSR_LOCKED       0x2
+#define OSLSR_LOCKED  0x2
 
-#define DAIF_DEBUG 0x200
+#define DAIF_DEBUG  0x200
 
 //
 // Assembly routines.
@@ -275,29 +275,30 @@ DebugArchInit (
 
   // Make sure debug exceptions are disable in the DAIF while configuring in case
   // there is some latent configuration.
-  Value = DebugReadDaif();
+  Value  = DebugReadDaif ();
   Value |= DAIF_DEBUG;
-  DebugWriteDaif(Value);
-  SpeculationBarrier();
+  DebugWriteDaif (Value);
+  SpeculationBarrier ();
 
   // Clear the OS lock if needed.
-  Value = DebugReadOslsrEl1();
+  Value = DebugReadOslsrEl1 ();
   if (Value & OSLSR_LOCKED) {
-    DebugWriteOslarEl1(0);
+    DebugWriteOslarEl1 (0);
   }
-  SpeculationBarrier();
+
+  SpeculationBarrier ();
 
   // Enable kernel and monitor debug bits.
   Value  = DebugReadMdscrEl1 ();
   Value |= (MDSCR_MDE | MDSCR_KDE);
   DebugWriteMdscrEl1 (Value);
-  SpeculationBarrier();
+  SpeculationBarrier ();
 
   // Make sure debug exceptions are enabled in the DAIF.
-  Value = DebugReadDaif();
+  Value  = DebugReadDaif ();
   Value &= ~DAIF_DEBUG;
-  DebugWriteDaif(Value);
-  SpeculationBarrier();
+  DebugWriteDaif (Value);
+  SpeculationBarrier ();
 }
 
 #define MIN_T0SZ        16

--- a/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/DebugAarch64.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/DebugAarch64.c
@@ -259,17 +259,12 @@ DebugGetTimeMs (
   @param[in]  DebugConfig       The debug configuration data.
 
 **/
-volatile BOOLEAN dbgloop = TRUE;
 VOID
 DebugArchInit (
   IN DEBUGGER_CONTROL_HOB  *DebugConfig
   )
 {
   UINT64  Value;
-
-  // while (dbgloop) {
-
-  // }
 
   //
   // For AARCH64 debugging to work, the following must be true.
@@ -278,13 +273,14 @@ DebugArchInit (
   //    3. Enabled debug exceptions in the DAIF
   //
 
-  // Make sure debug exceptions are disable in the DAIF while configuring.
+  // Make sure debug exceptions are disable in the DAIF while configuring in case
+  // there is some latent configuration.
   Value = DebugReadDaif();
   Value |= DAIF_DEBUG;
   DebugWriteDaif(Value);
   SpeculationBarrier();
 
-  // Clear the OS lock.
+  // Clear the OS lock if needed.
   Value = DebugReadOslsrEl1();
   if (Value & OSLSR_LOCKED) {
     DebugWriteOslarEl1(0);

--- a/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/Registers.S
+++ b/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/Registers.S
@@ -12,6 +12,10 @@
 
 GCC_ASM_EXPORT(DebugReadMdscrEl1)
 GCC_ASM_EXPORT(DebugWriteMdscrEl1)
+GCC_ASM_EXPORT(DebugReadOslsrEl1)
+GCC_ASM_EXPORT(DebugWriteOslsrEl1)
+GCC_ASM_EXPORT(DebugReadDaif)
+GCC_ASM_EXPORT(DebugWriteDaif)
 GCC_ASM_EXPORT(DebugGetTCR)
 GCC_ASM_EXPORT(DebugGetTTBR0BaseAddress)
 
@@ -21,6 +25,22 @@ ASM_PFX(DebugReadMdscrEl1):
 
 ASM_PFX(DebugWriteMdscrEl1):
     msr mdscr_el1, x0
+    ret
+
+ASM_PFX(DebugReadOslsrEl1):
+    mrs x0, oslsr_el1
+    ret
+
+ASM_PFX(DebugWriteOslsrEl1):
+    msr oslsr_el1, x0
+    ret
+
+ASM_PFX(DebugReadDaif):
+    mrs x0, daif
+    ret
+
+ASM_PFX(DebugWriteDaif):
+    msr daif, x0
     ret
 
 ASM_PFX(DebugGetTCR):

--- a/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/Registers.S
+++ b/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/Registers.S
@@ -13,7 +13,7 @@
 GCC_ASM_EXPORT(DebugReadMdscrEl1)
 GCC_ASM_EXPORT(DebugWriteMdscrEl1)
 GCC_ASM_EXPORT(DebugReadOslsrEl1)
-GCC_ASM_EXPORT(DebugWriteOslsrEl1)
+GCC_ASM_EXPORT(DebugWriteOslarEl1)
 GCC_ASM_EXPORT(DebugReadDaif)
 GCC_ASM_EXPORT(DebugWriteDaif)
 GCC_ASM_EXPORT(DebugGetTCR)
@@ -31,8 +31,8 @@ ASM_PFX(DebugReadOslsrEl1):
     mrs x0, oslsr_el1
     ret
 
-ASM_PFX(DebugWriteOslsrEl1):
-    msr oslsr_el1, x0
+ASM_PFX(DebugWriteOslarEl1):
+    msr oslar_el1, x0
     ret
 
 ASM_PFX(DebugReadDaif):

--- a/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/Registers.masm
+++ b/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/Registers.masm
@@ -9,6 +9,10 @@
 
     EXPORT DebugReadMdscrEl1
     EXPORT DebugWriteMdscrEl1
+    EXPORT DebugReadOslsrEl1
+    EXPORT DebugWriteOslarEl1
+    EXPORT DebugReadDaif
+    EXPORT DebugWriteDaif
     EXPORT DebugGetTCR
     EXPORT DebugGetTTBR0BaseAddress
 
@@ -23,6 +27,30 @@ DebugWriteMdscrEl1 PROC
   msr mdscr_el1, x0
   ret
 DebugWriteMdscrEl1 ENDP
+
+
+DebugReadOslsrEl1 PROC
+  mrs x0, oslsr_el1
+  ret
+DebugReadOslsrEl1 ENDP
+
+
+DebugWriteOslarEl1 PROC
+  msr oslar_el1, x0
+  ret
+DebugWriteOslarEl1 ENDP
+
+
+DebugReadDaif PROC
+  mrs x0, daif
+  ret
+DebugReadDaif ENDP
+
+
+DebugWriteDaif PROC
+  msr daif, x0
+  ret
+DebugWriteDaif ENDP
 
 
 DebugGetTCR PROC

--- a/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStub.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStub.c
@@ -140,6 +140,7 @@ SendGdbAck (
   @param[in] VA_LIST       Additional arguments for the formatting.
 
 **/
+/*
 STATIC
 VOID
 GdbNotifyLog (
@@ -168,6 +169,7 @@ GdbNotifyLog (
 
   DebugTransportWrite ((UINT8 *)&String[0], Length);
 }
+*/
 
 /**
   Sends a checksummed GDB packet response.

--- a/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStub.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStub.c
@@ -152,15 +152,15 @@ GdbNotifyLog (
   UINT8    Checksum;
   CHAR8    String[64];
 
-  Length = sizeof("%log:") - 1;
-  CopyMem(String, "%log:", Length);
+  Length = sizeof ("%log:") - 1;
+  CopyMem (String, "%log:", Length);
 
   VA_START (Marker, FormatString);
-  Length += AsciiVSPrint (&String[Length], sizeof(String) - Length - 4, FormatString, Marker);
+  Length += AsciiVSPrint (&String[Length], sizeof (String) - Length - 4, FormatString, Marker);
   VA_END (Marker);
 
-  Checksum  = CalculateSum8 ((UINT8 *)&String[1], Length - 1);
-  String[Length] = '#';
+  Checksum           = CalculateSum8 ((UINT8 *)&String[1], Length - 1);
+  String[Length]     = '#';
   String[Length + 1] = HexChars[Checksum >> 4];
   String[Length + 2] = HexChars[Checksum & 0xF];
   String[Length + 3] = 0;

--- a/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStub.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStub.c
@@ -1220,8 +1220,6 @@ ReportEntryToDebugger (
   gExceptionInfo = ExceptionInfo;
   gRunning       = FALSE;
 
-  GdbNotifyLog("Debug Entry");
-
   // Squelch logging output, it can confuse the debugger.
   TransportLogSuspend ();
 
@@ -1252,8 +1250,6 @@ ReportEntryToDebugger (
   if (mRebootOnContinue) {
     DebugReboot ();
   }
-
-  GdbNotifyLog("Debug Exit");
 
   // Re-enable logging prints.
   TransportLogResume ();


### PR DESCRIPTION
## Description

On AARCH64 processors single step was not working on real hardware because either 1. the OS lock register was set, or 2. the DEBUG exceptions were masked by the DAIF configuration. This makes sure neither are true in debugger configuration.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Manually tested on an AARCH64 machine.

## Integration Instructions

N/A
