### PR TITLE
Implement hardware watchpoints or data breakpoints

### DIFF
--- a/DebuggerFeaturePkg/DebuggerFeaturePkg.ci.yaml
+++ b/DebuggerFeaturePkg/DebuggerFeaturePkg.ci.yaml
@@ -54,6 +54,8 @@
         "IgnoreFiles": [],           # use gitignore syntax to ignore errors in matching files
         "ExtendWords": [             # words to extend to the dictionary for this package
             "baddr",
+            "dbgwcr",
+            "dbgwvr",
             "clsid",
             "exdicmd",
             "hresult",

--- a/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/DebugAarch64.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/DebugAarch64.c
@@ -34,20 +34,20 @@
 
 typedef union _DBG_WCR {
   struct {
-    UINTN  Enabled:1;
-    UINTN  Pac:2;
-    UINTN  Lsc:2;
-    UINTN  Bas:8;
-    UINTN  Hmc:1;
-    UINTN  Ssc:2;
-    UINTN  Lbn:4;
-    UINTN  Wt:1;
-    UINTN  Res0:3;
-    UINTN  Mask:5;
-    UINTN  Ssce:1;
-    UINTN  Res1:34;
+    UINTN    Enabled : 1;
+    UINTN    Pac     : 2;
+    UINTN    Lsc     : 2;
+    UINTN    Bas     : 8;
+    UINTN    Hmc     : 1;
+    UINTN    Ssc     : 2;
+    UINTN    Lbn     : 4;
+    UINTN    Wt      : 1;
+    UINTN    Res0    : 3;
+    UINTN    Mask    : 5;
+    UINTN    Ssce    : 1;
+    UINTN    Res1    : 34;
   } Bits;
-  UINTN UintN;
+  UINTN    UintN;
 } DBG_WCR;
 
 //
@@ -72,25 +72,25 @@ UINT64
 typedef
 VOID
 (*DEBUG_WRITE_REGISTER)(
-  UINT64 Value
+  UINT64  Value
   );
 
 typedef struct _DEBUG_WATCHPOINT_REGISTERS {
-  DEBUG_READ_REGISTER ReadValue;
-  DEBUG_WRITE_REGISTER WriteValue;
-  DEBUG_READ_REGISTER ReadControl;
-  DEBUG_WRITE_REGISTER WriteControl;
+  DEBUG_READ_REGISTER     ReadValue;
+  DEBUG_WRITE_REGISTER    WriteValue;
+  DEBUG_READ_REGISTER     ReadControl;
+  DEBUG_WRITE_REGISTER    WriteControl;
 } DEBUG_WATCHPOINT_REGISTERS;
 
-DEBUG_WATCHPOINT_REGISTERS DebugWatchpointRegisters[] = {
-  {DebugReadDbgWvr0El1, DebugWriteDbgWvr0El1, DebugReadDbgWcr0El1, DebugWriteDbgWcr0El1},
-  {DebugReadDbgWvr1El1, DebugWriteDbgWvr1El1, DebugReadDbgWcr1El1, DebugWriteDbgWcr1El1},
-  {DebugReadDbgWvr2El1, DebugWriteDbgWvr2El1, DebugReadDbgWcr2El1, DebugWriteDbgWcr2El1},
-  {DebugReadDbgWvr3El1, DebugWriteDbgWvr3El1, DebugReadDbgWcr3El1, DebugWriteDbgWcr3El1}
+DEBUG_WATCHPOINT_REGISTERS  DebugWatchpointRegisters[] = {
+  { DebugReadDbgWvr0El1, DebugWriteDbgWvr0El1, DebugReadDbgWcr0El1, DebugWriteDbgWcr0El1 },
+  { DebugReadDbgWvr1El1, DebugWriteDbgWvr1El1, DebugReadDbgWcr1El1, DebugWriteDbgWcr1El1 },
+  { DebugReadDbgWvr2El1, DebugWriteDbgWvr2El1, DebugReadDbgWcr2El1, DebugWriteDbgWcr2El1 },
+  { DebugReadDbgWvr3El1, DebugWriteDbgWvr3El1, DebugReadDbgWcr3El1, DebugWriteDbgWcr3El1 }
 };
 
 // Most hardware implementation support more then 4, but thi
-#define MAX_WATCHPOINTS (sizeof(DebugWatchpointRegisters) / sizeof(DebugWatchpointRegisters[0]))
+#define MAX_WATCHPOINTS  (sizeof(DebugWatchpointRegisters) / sizeof(DebugWatchpointRegisters[0]))
 
 /**
   This routine handles synchronous exceptions.
@@ -302,7 +302,7 @@ DebugArchInit (
 
   // Clear watchpoints.
   for (Index = 0; Index < MAX_WATCHPOINTS; Index++) {
-    DebugWatchpointRegisters[Index].WriteControl(0);
+    DebugWatchpointRegisters[Index].WriteControl (0);
   }
 
   SpeculationBarrier ();
@@ -482,41 +482,40 @@ AddWatchpoint (
   IN BOOLEAN  Write
   )
 {
-  UINTN Index;
-  UINTN Bas;
-  UINTN Lsc;
-  DBG_WCR DbgWcr;
-
+  UINTN    Index;
+  UINTN    Bas;
+  UINTN    Lsc;
+  DBG_WCR  DbgWcr;
 
   // Byte Address Select is a bitmap where each bit in Address + N up to +7.
   // shift away full 8 by (8 - count) to get this.
-  Bas = (0xFF >> (8 - MIN(Length, 8)));
+  Bas = (0xFF >> (8 - MIN (Length, 8)));
   Lsc = (Read ? BIT0 : 0) | (Write ? BIT1 : 0);
 
   // Check for duplicates.
   for (Index = 0; Index < MAX_WATCHPOINTS; Index++) {
-    DbgWcr.UintN = DebugWatchpointRegisters[Index].ReadControl();
-    if (DbgWcr.Bits.Enabled && (DbgWcr.Bits.Bas == Bas) && (DbgWcr.Bits.Lsc == Lsc) && DebugWatchpointRegisters[Index].ReadValue() == Address) {
+    DbgWcr.UintN = DebugWatchpointRegisters[Index].ReadControl ();
+    if (DbgWcr.Bits.Enabled && (DbgWcr.Bits.Bas == Bas) && (DbgWcr.Bits.Lsc == Lsc) && (DebugWatchpointRegisters[Index].ReadValue () == Address)) {
       return TRUE;
     }
   }
 
   // Find an empty spot and fill it.
   for (Index = 0; Index < MAX_WATCHPOINTS; Index++) {
-    DbgWcr.UintN = DebugWatchpointRegisters[Index].ReadControl();
+    DbgWcr.UintN = DebugWatchpointRegisters[Index].ReadControl ();
     if (!DbgWcr.Bits.Enabled) {
-      DbgWcr.UintN = 0;
+      DbgWcr.UintN        = 0;
       DbgWcr.Bits.Enabled = 1;
-      DbgWcr.Bits.Lsc = Lsc;
-      DbgWcr.Bits.Bas = Bas;
+      DbgWcr.Bits.Lsc     = Lsc;
+      DbgWcr.Bits.Bas     = Bas;
 
       // These are required to trap at all level in the normal world. Refer to
       // table D2-13 in the ARM A profile reference manual.
       DbgWcr.Bits.Hmc = 1;
       DbgWcr.Bits.Ssc = 0b01;
       DbgWcr.Bits.Pac = 0b11;
-      DebugWatchpointRegisters[Index].WriteValue(Address);
-      DebugWatchpointRegisters[Index].WriteControl(DbgWcr.UintN);
+      DebugWatchpointRegisters[Index].WriteValue (Address);
+      DebugWatchpointRegisters[Index].WriteControl (DbgWcr.UintN);
       return TRUE;
     }
   }
@@ -543,22 +542,21 @@ RemoveWatchpoint (
   IN BOOLEAN  Write
   )
 {
-  UINTN Index;
-  UINTN Bas;
-  UINTN Lsc;
-  DBG_WCR DbgWcr;
-
+  UINTN    Index;
+  UINTN    Bas;
+  UINTN    Lsc;
+  DBG_WCR  DbgWcr;
 
   // Byte Address Select is a bitmap where each bit in Address + N up to +7.
   // shift away full 8 by (8 - count) to get this.
-  Bas = (0xFF >> (8 - MIN(Length, 8)));
+  Bas = (0xFF >> (8 - MIN (Length, 8)));
   Lsc = (Read ? BIT0 : 0) | (Write ? BIT1 : 0);
 
   // Check for duplicates.
   for (Index = 0; Index < MAX_WATCHPOINTS; Index++) {
-    DbgWcr.UintN = DebugWatchpointRegisters[Index].ReadControl();
-    if (DbgWcr.Bits.Enabled && (DbgWcr.Bits.Bas == Bas) && (DbgWcr.Bits.Lsc == Lsc) && (DebugWatchpointRegisters[Index].ReadValue() == Address)) {
-      DebugWatchpointRegisters[Index].WriteControl(0);
+    DbgWcr.UintN = DebugWatchpointRegisters[Index].ReadControl ();
+    if (DbgWcr.Bits.Enabled && (DbgWcr.Bits.Bas == Bas) && (DbgWcr.Bits.Lsc == Lsc) && (DebugWatchpointRegisters[Index].ReadValue () == Address)) {
+      DebugWatchpointRegisters[Index].WriteControl (0);
       return TRUE;
     }
   }

--- a/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/DebugAarch64.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/DebugAarch64.c
@@ -89,7 +89,8 @@ DEBUG_WATCHPOINT_REGISTERS  DebugWatchpointRegisters[] = {
   { DebugReadDbgWvr3El1, DebugWriteDbgWvr3El1, DebugReadDbgWcr3El1, DebugWriteDbgWcr3El1 }
 };
 
-// Most hardware implementation support more then 4, but thi
+// Most hardware implementation support more then 4. This was a chosen upper bound
+// to avoid adding too much assembly wrapper code.
 #define MAX_WATCHPOINTS  (sizeof(DebugWatchpointRegisters) / sizeof(DebugWatchpointRegisters[0]))
 
 /**

--- a/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/DebugAarch64.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/DebugAarch64.c
@@ -487,9 +487,13 @@ AddWatchpoint (
   UINTN    Lsc;
   DBG_WCR  DbgWcr;
 
+  if (Length == 0) {
+    return FALSE;
+  }
+
   // Byte Address Select is a bitmap where each bit in Address + N up to +7.
   // shift away full 8 by (8 - count) to get this.
-  Bas = (0xFF >> (8 - MIN (Length, 8)));
+  Bas = RShiftU64 (0xFF, (8 - MIN (Length, 8)));
   Lsc = (Read ? BIT0 : 0) | (Write ? BIT1 : 0);
 
   // Check for duplicates.
@@ -547,9 +551,13 @@ RemoveWatchpoint (
   UINTN    Lsc;
   DBG_WCR  DbgWcr;
 
+  if (Length == 0) {
+    return FALSE;
+  }
+
   // Byte Address Select is a bitmap where each bit in Address + N up to +7.
   // shift away full 8 by (8 - count) to get this.
-  Bas = (0xFF >> (8 - MIN (Length, 8)));
+  Bas = RShiftU64 (0xFF, (8 - MIN (Length, 8)));
   Lsc = (Read ? BIT0 : 0) | (Write ? BIT1 : 0);
 
   // Check for duplicates.

--- a/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/Registers.S
+++ b/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/Registers.S
@@ -18,6 +18,22 @@ GCC_ASM_EXPORT(DebugReadDaif)
 GCC_ASM_EXPORT(DebugWriteDaif)
 GCC_ASM_EXPORT(DebugGetTCR)
 GCC_ASM_EXPORT(DebugGetTTBR0BaseAddress)
+GCC_ASM_EXPORT(DebugReadDbgWvr0El1)
+GCC_ASM_EXPORT(DebugWriteDbgWvr0El1)
+GCC_ASM_EXPORT(DebugReadDbgWcr0El1)
+GCC_ASM_EXPORT(DebugWriteDbgWcr0El1)
+GCC_ASM_EXPORT(DebugReadDbgWvr1El1)
+GCC_ASM_EXPORT(DebugWriteDbgWvr1El1)
+GCC_ASM_EXPORT(DebugReadDbgWcr1El1)
+GCC_ASM_EXPORT(DebugWriteDbgWcr1El1)
+GCC_ASM_EXPORT(DebugReadDbgWvr2El1)
+GCC_ASM_EXPORT(DebugWriteDbgWvr2El1)
+GCC_ASM_EXPORT(DebugReadDbgWcr2El1)
+GCC_ASM_EXPORT(DebugWriteDbgWcr2El1)
+GCC_ASM_EXPORT(DebugReadDbgWvr3El1)
+GCC_ASM_EXPORT(DebugWriteDbgWvr3El1)
+GCC_ASM_EXPORT(DebugReadDbgWcr3El1)
+GCC_ASM_EXPORT(DebugWriteDbgWcr3El1)
 
 ASM_PFX(DebugReadMdscrEl1):
     mrs x0, mdscr_el1
@@ -71,4 +87,68 @@ ASM_PFX(DebugGetTTBR0BaseAddress):
     ldr x1, =0xFFFFFFFFFFFF
     and x0, x0, x1
     isb
+    ret
+
+ASM_PFX(DebugReadDbgWvr0El1):
+    mrs x0, dbgwvr0_el1
+    ret
+
+ASM_PFX(DebugWriteDbgWvr0El1):
+    msr dbgwvr0_el1, x0
+    ret
+
+ASM_PFX(DebugReadDbgWcr0El1):
+    mrs x0, dbgwcr0_el1
+    ret
+
+ASM_PFX(DebugWriteDbgWcr0El1):
+    msr dbgwcr0_el1, x0
+    ret
+
+ASM_PFX(DebugReadDbgWvr1El1):
+    mrs x0, dbgwvr1_el1
+    ret
+
+ASM_PFX(DebugWriteDbgWvr1El1):
+    msr dbgwvr1_el1, x0
+    ret
+
+ASM_PFX(DebugReadDbgWcr1El1):
+    mrs x0, dbgwcr1_el1
+    ret
+
+ASM_PFX(DebugWriteDbgWcr1El1):
+    msr dbgwcr1_el1, x0
+    ret
+
+ASM_PFX(DebugReadDbgWvr2El1):
+    mrs x0, dbgwvr2_el1
+    ret
+
+ASM_PFX(DebugWriteDbgWvr2El1):
+    msr dbgwvr2_el1, x0
+    ret
+
+ASM_PFX(DebugReadDbgWcr2El1):
+    mrs x0, dbgwcr2_el1
+    ret
+
+ASM_PFX(DebugWriteDbgWcr2El1):
+    msr dbgwcr2_el1, x0
+    ret
+
+ASM_PFX(DebugReadDbgWvr3El1):
+    mrs x0, dbgwvr3_el1
+    ret
+
+ASM_PFX(DebugWriteDbgWvr3El1):
+    msr dbgwvr3_el1, x0
+    ret
+
+ASM_PFX(DebugReadDbgWcr3El1):
+    mrs x0, dbgwcr3_el1
+    ret
+
+ASM_PFX(DebugWriteDbgWcr3El1):
+    msr dbgwcr3_el1, x0
     ret

--- a/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/Registers.h
+++ b/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/Registers.h
@@ -68,6 +68,7 @@ VOID
 DebugWriteDbgWcr0El1 (
   IN UINT64  Value
   );
+
 UINT64
 DebugReadDbgWvr1El1 (
   VOID
@@ -87,6 +88,7 @@ VOID
 DebugWriteDbgWcr1El1 (
   IN UINT64  Value
   );
+
 UINT64
 DebugReadDbgWvr2El1 (
   VOID
@@ -106,6 +108,7 @@ VOID
 DebugWriteDbgWcr2El1 (
   IN UINT64  Value
   );
+
 UINT64
 DebugReadDbgWvr3El1 (
   VOID

--- a/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/Registers.h
+++ b/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/Registers.h
@@ -1,0 +1,129 @@
+/** @file
+  Prototypes for assembly routines for accessing system registers.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __DEBUG_REGISTERS_H__
+#define __DEBUG_REGISTERS_H__
+
+UINT64
+DebugReadMdscrEl1 (
+  VOID
+  );
+
+VOID
+DebugWriteMdscrEl1 (
+  IN UINT64  Value
+  );
+
+UINT64
+DebugReadDaif (
+  VOID
+  );
+
+VOID
+DebugWriteDaif (
+  IN UINT64  Value
+  );
+
+UINT64
+DebugReadOslsrEl1 (
+  VOID
+  );
+
+VOID
+DebugWriteOslarEl1 (
+  IN UINT64  Value
+  );
+
+UINT64
+DebugGetTCR (
+  VOID
+  );
+
+UINT64
+DebugGetTTBR0BaseAddress (
+  VOID
+  );
+
+UINT64
+DebugReadDbgWvr0El1 (
+  VOID
+  );
+
+VOID
+DebugWriteDbgWvr0El1 (
+  IN UINT64  Value
+  );
+
+UINT64
+DebugReadDbgWcr0El1 (
+  VOID
+  );
+
+VOID
+DebugWriteDbgWcr0El1 (
+  IN UINT64  Value
+  );
+UINT64
+DebugReadDbgWvr1El1 (
+  VOID
+  );
+
+VOID
+DebugWriteDbgWvr1El1 (
+  IN UINT64  Value
+  );
+
+UINT64
+DebugReadDbgWcr1El1 (
+  VOID
+  );
+
+VOID
+DebugWriteDbgWcr1El1 (
+  IN UINT64  Value
+  );
+UINT64
+DebugReadDbgWvr2El1 (
+  VOID
+  );
+
+VOID
+DebugWriteDbgWvr2El1 (
+  IN UINT64  Value
+  );
+
+UINT64
+DebugReadDbgWcr2El1 (
+  VOID
+  );
+
+VOID
+DebugWriteDbgWcr2El1 (
+  IN UINT64  Value
+  );
+UINT64
+DebugReadDbgWvr3El1 (
+  VOID
+  );
+
+VOID
+DebugWriteDbgWvr3El1 (
+  IN UINT64  Value
+  );
+
+UINT64
+DebugReadDbgWcr3El1 (
+  VOID
+  );
+
+VOID
+DebugWriteDbgWcr3El1 (
+  IN UINT64  Value
+  );
+
+#endif

--- a/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/Registers.h
+++ b/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/Registers.h
@@ -6,8 +6,8 @@
 
 **/
 
-#ifndef __DEBUG_REGISTERS_H__
-#define __DEBUG_REGISTERS_H__
+#ifndef DEBUG_REGISTERS_H__
+#define DEBUG_REGISTERS_H__
 
 UINT64
 DebugReadMdscrEl1 (

--- a/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/Registers.masm
+++ b/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/Registers.masm
@@ -15,6 +15,22 @@
     EXPORT DebugWriteDaif
     EXPORT DebugGetTCR
     EXPORT DebugGetTTBR0BaseAddress
+    EXPORT DebugReadDbgWvr0El1
+    EXPORT DebugWriteDbgWvr0El1
+    EXPORT DebugReadDbgWcr0El1
+    EXPORT DebugWriteDbgWcr0El1
+    EXPORT DebugReadDbgWvr1El1
+    EXPORT DebugWriteDbgWvr1El1
+    EXPORT DebugReadDbgWcr1El1
+    EXPORT DebugWriteDbgWcr1El1
+    EXPORT DebugReadDbgWvr2El1
+    EXPORT DebugWriteDbgWvr2El1
+    EXPORT DebugReadDbgWcr2El1
+    EXPORT DebugWriteDbgWcr2El1
+    EXPORT DebugReadDbgWvr3El1
+    EXPORT DebugWriteDbgWvr3El1
+    EXPORT DebugReadDbgWcr3El1
+    EXPORT DebugWriteDbgWcr3El1
 
 
 DebugReadMdscrEl1 PROC
@@ -85,6 +101,101 @@ DebugGetTTBR0BaseAddress PROC
   isb   sy
   ret
 ArmGetTTBR0BaseAddress ENDP
+
+DebugReadDbgWvr0El1 PROC
+    mrs x0, dbgwvr0_el1
+    ret
+DebugReadDbgWvr0El1 ENDP
+
+
+DebugWriteDbgWvr0El1 PROC
+    msr dbgwvr0_el1, x0
+    ret
+DebugWriteDbgWvr0El1 ENDP
+
+
+DebugReadDbgWcr0El1 PROC
+    mrs x0, dbgwcr0_el1
+    ret
+DebugReadDbgWcr0El1 ENDP
+
+
+DebugWriteDbgWcr0El1 PROC
+    msr dbgwcr0_el1, x0
+    ret
+DebugWriteDbgWcr0El1 ENDP
+
+
+DebugReadDbgWvr1El1 PROC
+    mrs x0, dbgwvr1_el1
+    ret
+DebugReadDbgWvr1El1 ENDP
+
+
+DebugWriteDbgWvr1El1 PROC
+    msr dbgwvr1_el1, x0
+    ret
+DebugWriteDbgWvr1El1 ENDP
+
+
+DebugReadDbgWcr1El1 PROC
+    mrs x0, dbgwcr1_el1
+    ret
+DebugReadDbgWcr1El1 ENDP
+
+
+DebugWriteDbgWcr1El1 PROC
+    msr dbgwcr1_el1, x0
+    ret
+DebugWriteDbgWcr1El1 ENDP
+
+
+DebugReadDbgWvr2El1 PROC
+    mrs x0, dbgwvr2_el1
+    ret
+DebugReadDbgWvr2El1 ENDP
+
+
+DebugWriteDbgWvr2El1 PROC
+    msr dbgwvr2_el1, x0
+    ret
+DebugWriteDbgWvr2El1 ENDP
+
+
+DebugReadDbgWcr2El1 PROC
+    mrs x0, dbgwcr2_el1
+    ret
+DebugReadDbgWcr2El1 ENDP
+
+
+DebugWriteDbgWcr2El1 PROC
+    msr dbgwcr2_el1, x0
+    ret
+DebugWriteDbgWcr2El1 ENDP
+
+
+DebugReadDbgWvr3El1 PROC
+    mrs x0, dbgwvr3_el1
+    ret
+DebugReadDbgWvr3El1 ENDP
+
+
+DebugWriteDbgWvr3El1 PROC
+    msr dbgwvr3_el1, x0
+    ret
+DebugWriteDbgWvr3El1 ENDP
+
+
+DebugReadDbgWcr3El1 PROC
+    mrs x0, dbgwcr3_el1
+    ret
+DebugReadDbgWcr3El1 ENDP
+
+
+DebugWriteDbgWcr3El1 PROC
+    msr dbgwcr3_el1, x0
+    ret
+DebugWriteDbgWcr3El1 ENDP
 
 
     END

--- a/DebuggerFeaturePkg/Library/DebugAgent/DebugAgent.h
+++ b/DebuggerFeaturePkg/Library/DebugAgent/DebugAgent.h
@@ -206,18 +206,18 @@ DebugArchInit (
 
 BOOLEAN
 AddWatchpoint (
-  IN UINTN Address,
-  IN UINTN Length,
-  IN BOOLEAN Read,
-  IN BOOLEAN Write
+  IN UINTN    Address,
+  IN UINTN    Length,
+  IN BOOLEAN  Read,
+  IN BOOLEAN  Write
   );
 
 BOOLEAN
 RemoveWatchpoint (
-  IN UINTN Address,
-  IN UINTN Length,
-  IN BOOLEAN Read,
-  IN BOOLEAN Write
+  IN UINTN    Address,
+  IN UINTN    Length,
+  IN BOOLEAN  Read,
+  IN BOOLEAN  Write
   );
 
 #endif

--- a/DebuggerFeaturePkg/Library/DebugAgent/DebugAgent.h
+++ b/DebuggerFeaturePkg/Library/DebugAgent/DebugAgent.h
@@ -204,4 +204,20 @@ DebugArchInit (
   IN DEBUGGER_CONTROL_HOB  *DebugConfig
   );
 
+BOOLEAN
+AddWatchpoint (
+  IN UINTN Address,
+  IN UINTN Length,
+  IN BOOLEAN Read,
+  IN BOOLEAN Write
+  );
+
+BOOLEAN
+RemoveWatchpoint (
+  IN UINTN Address,
+  IN UINTN Length,
+  IN BOOLEAN Read,
+  IN BOOLEAN Write
+  );
+
 #endif

--- a/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.inf
+++ b/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.inf
@@ -33,6 +33,7 @@
   AARCH64/DebugAarch64.c
   AARCH64/Registers.masm | MSFT
   AARCH64/Registers.S | GCC
+  AARCH64/Registers.h
   GdbStub/GdbStubAarch64.c
 
 [Sources.X64]

--- a/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStubX64.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStubX64.c
@@ -133,15 +133,27 @@ GdbDumpSystemRegisters (
   AsciiSPrint (
     Response,
     BufferLength,
-    "\r\n",
+    "\r\n"
     "IDT: %llx : %x\n\r"
     "GDT: %llx : %x\n\r"
     "TR:  %x\n\r"
+    "DR0: %llx\n\r"
+    "DR1: %llx\n\r"
+    "DR2: %llx\n\r"
+    "DR3: %llx\n\r"
+    "DR6: %llx\n\r"
+    "DR7: %llx\n\r"
     "\r\n",
     Idtr.Base,
     Idtr.Limit,
     Gdtr.Base,
     Gdtr.Limit,
-    AsmReadTr ()
+    AsmReadTr (),
+    AsmReadDr0 (),
+    AsmReadDr1 (),
+    AsmReadDr2 (),
+    AsmReadDr3 (),
+    AsmReadDr6 (),
+    AsmReadDr7 ()
     );
 }

--- a/DebuggerFeaturePkg/Library/DebugAgent/X64/DebugX64.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/X64/DebugX64.c
@@ -23,6 +23,39 @@
 
 #define TF_BIT  0x00000100
 
+// Debug registers defines.
+#define DR7_ENABLE_MASK  0xFF
+#define DR7_WRITE_ONLY   0b01
+#define DR7_READ_WRITE   0b11
+
+typedef union _X64_DR7 {
+  struct {
+    UINTN    L0         : 1;  // Local breakpoint enable
+    UINTN    G0         : 1;  // Global breakpoint enable
+    UINTN    L1         : 1;  // Local breakpoint enable
+    UINTN    G1         : 1;  // Global breakpoint enable
+    UINTN    L2         : 1;  // Local breakpoint enable
+    UINTN    G2         : 1;  // Global breakpoint enable
+    UINTN    L3         : 1;  // Local breakpoint enable
+    UINTN    G3         : 1;  // Global breakpoint enable
+    UINTN    LE         : 1;  // Local exact breakpoint enable
+    UINTN    GE         : 1;  // Global exact breakpoint enable
+    UINTN    Reserved_1 : 3;  // Reserved
+    UINTN    GD         : 1;  // Global detect enable
+    UINTN    Reserved_2 : 2;  // Reserved
+    UINTN    RW0        : 2;  // Read/Write field
+    UINTN    LEN0       : 2;  // Length field
+    UINTN    RW1        : 2;  // Read/Write field
+    UINTN    LEN1       : 2;  // Length field
+    UINTN    RW2        : 2;  // Read/Write field
+    UINTN    LEN2       : 2;  // Length field
+    UINTN    RW3        : 2;  // Read/Write field
+    UINTN    LEN3       : 2;  // Length field
+    UINTN    Reserved_3 : 32; // Length field
+  } Bits;
+  UINTN    UintN;
+} X64_DR7;
+
 extern EFI_CPU_ARCH_PROTOCOL  *gCpu;
 STATIC UINT64                 mPerformanceCounterFreq;
 
@@ -179,5 +212,152 @@ DebugArchInit (
   IN DEBUGGER_CONTROL_HOB  *DebugConfig
   )
 {
+  // Disable hardware breakpoints.
+  UINTN  Dr7;
+
+  // Disable first.
+  Dr7 = AsmReadDr7 ();
+  AsmWriteDr7 (Dr7 & ~DR7_ENABLE_MASK);
+
+  // Set stashed TSC frequency
   mPerformanceCounterFreq = DebugConfig->PerformanceCounterFreq;
+}
+
+/**
+  Converts a byte count length to the x64 debug register representation. Unsupported
+  sizes will default to 1 byte.
+
+  @param[in]  Length    The byte count length.
+
+  @retval   UINTN the x64 debug register representation.
+**/
+UINTN
+LengthToDebugRegLen (
+  IN UINTN  Length
+  )
+{
+  switch (Length) {
+    case 8:
+      return 0b10;
+    case 4:
+      return 0b11;
+    case 2:
+      return 0b01;
+    case 1:
+    default:
+      return 0b00;
+  }
+}
+
+/**
+  Adds a X64 hardware watch point.
+
+  @param[in]  Address   The address of the data watch point.
+  @param[in]  Length    The length of the data watch point.
+  @param[in]  Read      Boolean indicated break on read.
+  @param[in]  Write     Boolean indicated break on write.
+
+  @retval  TRUE   The watch point was successfully set.
+  @retval  FALSE  The watch point could not be set.
+**/
+BOOLEAN
+AddWatchpoint (
+  IN UINTN    Address,
+  IN UINTN    Length,
+  IN BOOLEAN  Read,
+  IN BOOLEAN  Write
+  )
+{
+  X64_DR7  Dr7;
+  UINTN    Rw;
+  UINTN    Len;
+
+  // Only READ is not supported, so only check only write condition
+  Rw        = Read ? DR7_READ_WRITE : DR7_WRITE_ONLY;
+  Len       = LengthToDebugRegLen (Length);
+  Dr7.UintN = AsmReadDr7 ();
+
+  // Check for duplicate.
+  if (Dr7.Bits.L0 && (Dr7.Bits.RW0 == Rw) && (Dr7.Bits.LEN0 == Len) && (AsmReadDr0 () == Address)) {
+    return TRUE;
+  } else if (Dr7.Bits.L1 && (Dr7.Bits.RW1 == Rw) && (Dr7.Bits.LEN1 == Len) && (AsmReadDr1 () == Address)) {
+    return TRUE;
+  } else if (Dr7.Bits.L2 && (Dr7.Bits.RW2 == Rw) && (Dr7.Bits.LEN2 == Len) && (AsmReadDr2 () == Address)) {
+    return TRUE;
+  } else if (Dr7.Bits.L3 && (Dr7.Bits.RW3 == Rw) && (Dr7.Bits.LEN3 == Len) && (AsmReadDr3 () == Address)) {
+    return TRUE;
+  }
+
+  // find a free breakpoint.
+  if (!Dr7.Bits.L0) {
+    AsmWriteDr0 (Address);
+    Dr7.Bits.L0   = 1;
+    Dr7.Bits.RW0  = Rw;
+    Dr7.Bits.LEN0 = Len;
+  } else if (!Dr7.Bits.L1) {
+    AsmWriteDr1 (Address);
+    Dr7.Bits.L1   = 1;
+    Dr7.Bits.RW1  = Rw;
+    Dr7.Bits.LEN1 = Len;
+  } else if (!Dr7.Bits.L2) {
+    AsmWriteDr2 (Address);
+    Dr7.Bits.L2   = 1;
+    Dr7.Bits.RW2  = Rw;
+    Dr7.Bits.LEN2 = Len;
+  } else if (!Dr7.Bits.L3) {
+    AsmWriteDr3 (Address);
+    Dr7.Bits.L3   = 1;
+    Dr7.Bits.RW3  = Rw;
+    Dr7.Bits.LEN3 = Len;
+  } else {
+    return FALSE;
+  }
+
+  AsmWriteDr7 (Dr7.UintN);
+  return TRUE;
+}
+
+/**
+  Removes a X64 hardware watch point.
+
+  @param[in]  Address   The address of the data watch point.
+  @param[in]  Length    The length of the data watch point.
+  @param[in]  Read      Boolean indicated break on read.
+  @param[in]  Write     Boolean indicated break on write.
+
+  @retval  TRUE   The watch point was successfully removed.
+  @retval  FALSE  The watch point could not be removed or did not exist.
+**/
+BOOLEAN
+RemoveWatchpoint (
+  IN UINTN    Address,
+  IN UINTN    Length,
+  IN BOOLEAN  Read,
+  IN BOOLEAN  Write
+  )
+{
+  X64_DR7  Dr7;
+  UINT8    Rw;
+  UINTN    Len;
+
+  // Only READ is not supported, so only check only write condition
+  Rw        = Read ? DR7_READ_WRITE : DR7_WRITE_ONLY;
+  Len       = LengthToDebugRegLen (Length);
+  Dr7.UintN = AsmReadDr7 ();
+
+  // Check for duplicate.
+  if (Dr7.Bits.L0 && (Dr7.Bits.RW0 == Rw) && (Dr7.Bits.LEN0 == Len) && (AsmReadDr0 () == Address)) {
+    Dr7.Bits.L0 = 0;
+  } else if (Dr7.Bits.L1 && (Dr7.Bits.RW1 == Rw) && (Dr7.Bits.LEN1 == Len) && (AsmReadDr1 () == Address)) {
+    Dr7.Bits.L1 = 0;
+  } else if (Dr7.Bits.L2 && (Dr7.Bits.RW2 == Rw) && (Dr7.Bits.LEN2 == Len) && (AsmReadDr2 () == Address)) {
+    Dr7.Bits.L2 = 0;
+  } else if (Dr7.Bits.L3 && (Dr7.Bits.RW3 == Rw) && (Dr7.Bits.LEN3 == Len) && (AsmReadDr3 () == Address)) {
+    Dr7.Bits.L3 = 0;
+  } else {
+    return FALSE;
+  }
+
+  AsmWriteDr7 (Dr7.UintN);
+  return TRUE;
 }

--- a/DebuggerFeaturePkg/Readme.md
+++ b/DebuggerFeaturePkg/Readme.md
@@ -27,6 +27,25 @@ debugger initializes on libraries or custom implementations such as for page tab
 walks or exceptions handlers, it will attempt to use the protocols once available
 for consistency.
 
+## Supported Functionality
+
+The following functionality is supported by the UEFI Debugger.
+
+| Feature                          | State        | Notes                             |
+|----------------------------------|--------------|-----------------------------------|
+| Memory Read/Write                | Supported    | |
+| General Purpose Register R/W     | Supported    | |
+| Instruction Stepping             | Supported    | |
+| Interrupt break                  | Supported    | |
+| System Register Access           | Partial      | Partially supported read through monitor commands |
+| SW Breakpoints                   | Supported    | |
+| Watch points / Data Breakpoints  | Supported    | |
+| HW Breakpoints                   | Unsupported  | Not currently needed with SW breakpoints |
+| Break on module load             | Supported    | Supported through monitor command |
+| Reboot                           | Supported    | Supplemented with monitor command for better use |
+| UEFI Variable Access             | Planned      | Planned support by monitor command |
+| Multithread Support              | Planned      | Currently only exposes the BSP thread/core |
+
 ## Enabling the debugger
 
 The [DebugAgent library](./Library/DebugAgent/) implements the debug logic and is


### PR DESCRIPTION
## Description

Implement up to 4 watchpoints, or data breakpoints, which are represented by the GDB breakpoints types 2-4. These can be set in windbg by using the `ba` command, e.g. `ba w8 0x10000001`. These can be set in GDB by using the `watch` for writes, `rwatch` for reads, or `awatch` for either.

#33 


- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Q35 and SBSA on QEMU.

## Integration Instructions

N/A
