### PR TITLE
Do not treat RP memory as valid for access

### DIFF
--- a/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.c
@@ -477,7 +477,6 @@ AccessMemory (
 
         AttributesChanged = TRUE;
       }
-
     } else if (Write) {
       if (!IsPageWritable (Address)) {
         return FALSE;

--- a/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.c
@@ -459,24 +459,17 @@ AccessMemory (
         return FALSE;
       }
 
+      if (Attributes & EFI_MEMORY_RP) {
+        // Treat RP memory as non-valid.
+        return FALSE;
+      }
+
       if (Write && (Attributes & EFI_MEMORY_RO)) {
         Status = mMemoryAttributeProtocol->ClearMemoryAttributes (
                                              mMemoryAttributeProtocol,
                                              Address & ~EFI_PAGE_MASK,
                                              EFI_PAGE_SIZE,
-                                             EFI_MEMORY_RO | EFI_MEMORY_RP
-                                             );
-        if (EFI_ERROR (Status)) {
-          return FALSE;
-        }
-
-        AttributesChanged = TRUE;
-      } else if (Attributes & EFI_MEMORY_RP) {
-        Status = mMemoryAttributeProtocol->ClearMemoryAttributes (
-                                             mMemoryAttributeProtocol,
-                                             Address & ~EFI_PAGE_MASK,
-                                             EFI_PAGE_SIZE,
-                                             EFI_MEMORY_RP
+                                             EFI_MEMORY_RO
                                              );
         if (EFI_ERROR (Status)) {
           return FALSE;
@@ -484,6 +477,7 @@ AccessMemory (
 
         AttributesChanged = TRUE;
       }
+
     } else if (Write) {
       if (!IsPageWritable (Address)) {
         return FALSE;


### PR DESCRIPTION
## Description

When accessing memory, treat read protected memory the same as non-resident VAs. There shouldn't be a need to read or write to these addresses and if so in the future they should be sup[ported through physical read/write instructions.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested in SBSA

## Integration Instructions

N/A
