### PR TITLE
Still break into the debugger on unknown exception handlers

### DIFF
--- a/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/DebugAarch64.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/AARCH64/DebugAarch64.c
@@ -179,11 +179,9 @@ DebuggerExceptionHandler (
       break;
 
     default:
-
-      //
-      // Miscellaneous unhandled situations
-      //
-      CpuDeadLoop ();
+      ExceptionInfo.ExceptionType    = ExceptionGenericFault;
+      ExceptionInfo.ExceptionAddress = Context->ELR;
+      break;
   }
 
   ExceptionInfo.ArchExceptionCode = ExceptionType;

--- a/DebuggerFeaturePkg/Library/DebugAgent/X64/DebugX64.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/X64/DebugX64.c
@@ -134,17 +134,10 @@ DebuggerExceptionHandler (
     case EXCEPT_X64_DOUBLE_FAULT:
     case EXCEPT_X64_SEG_NOT_PRESENT:
     case EXCEPT_X64_GP_FAULT:
+    default:
       ExceptionInfo.ExceptionType    = ExceptionGenericFault;
       ExceptionInfo.ExceptionAddress = Context->Rip;
       break;
-
-    default:
-
-      //
-      // Unhandled situations
-      //
-
-      CpuDeadLoop ();
   }
 
   ExceptionInfo.ArchExceptionCode = InterruptType;


### PR DESCRIPTION
## Description

Changes the default behavior from unknown exceptions from a cpu dead loop to still break into the debugger with a "generic fault" information 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
