### PR TITLE
Add PCD flag to allow disabling debugger polling

### DIFF
--- a/DebuggerFeaturePkg/DebuggerFeaturePkg.dec
+++ b/DebuggerFeaturePkg/DebuggerFeaturePkg.dec
@@ -43,8 +43,7 @@
   # Bit 0 - Controls whether the debugger will break in on initialization.
   # Bit 1 - Controls whether the DXE debugger is enabled.
   # Bit 2 - Controls whether the MM debugger is enabled.
-  # Bit 3 - Controls whether the debugger runs in minimal mode. If enabled, the
-  #         debugger will avoid using protocols and depend on static linked functionality.
+  # Bit 3 - Disables the debuggers periodic polling for a requested break-in.
   DebuggerFeaturePkgTokenSpaceGuid.PcdDebugConfigFlags|0x3|UINT32|0x00000001
 
   ## Controls the timeout for the initial breakpoint before continuing. 0 Indicates

--- a/DebuggerFeaturePkg/Include/DebuggerControlHob.h
+++ b/DebuggerFeaturePkg/Include/DebuggerControlHob.h
@@ -15,7 +15,8 @@ typedef struct _DEBUGGER_CONTROL_HOB {
       UINT32    InitialBreakpoint : 1;
       UINT32    DxeDebugEnabled   : 1;
       UINT32    MmDebugEnabled    : 1;
-      UINT32    Unused            : 29;
+      UINT32    DisablePolling    : 1;
+      UINT32    Unused            : 28;
     } Flags;
 
     UINT32    AsUint32;

--- a/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.c
@@ -63,6 +63,7 @@ STATIC EFI_EVENT  mCpuArchEvent;
 STATIC EFI_EVENT  mLoadedImageEvent;
 STATIC EFI_EVENT  mExitBootServicesEvent;
 STATIC BOOLEAN    mDebuggerInitialized;
+STATIC BOOLEAN    mDisablePolling;
 STATIC CHAR8      mDbgBreakOnModuleLoadString[64] = { 0 };
 
 /**
@@ -604,7 +605,7 @@ DxeDebugSetupCallbacks (
     }
   }
 
-  if (gTimer == NULL) {
+  if (!mDisablePolling && (gTimer == NULL)) {
     DEBUG ((DEBUG_INFO, "%a: Timer Arch protocol not installed. Registering for notification\n", __FUNCTION__));
     mTimerEvent = EfiCreateProtocolNotifyEvent (
                     &gEfiTimerArchProtocolGuid,
@@ -730,6 +731,7 @@ InitializeDebugAgent (
       return;
     }
 
+    mDisablePolling      = DebugHob->Control.Flags.DisablePolling;
     mDebuggerInitialized = TRUE;
 
     //

--- a/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/DebugAgentDxe.c
@@ -731,7 +731,7 @@ InitializeDebugAgent (
       return;
     }
 
-    mDisablePolling      = DebugHob->Control.Flags.DisablePolling;
+    mDisablePolling      = (DebugHob->Control.Flags.DisablePolling != 0);
     mDebuggerInitialized = TRUE;
 
     //


### PR DESCRIPTION
## Description

Adds a flag to the debugger PCD and HOB to allow polling for break from the debugger. This may be necissary for scenarios where the debugger and console share a serial port so that they do not contend over input while the debugger is not broken-in.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

