### PR TITLE
Flush the out queue to avoid mistaking uefi log content for gdb command response

### DIFF
--- a/DebuggerFeaturePkg/Readme.md
+++ b/DebuggerFeaturePkg/Readme.md
@@ -205,11 +205,11 @@ GDB is currently only functional with AARCH64 due to bugs in the x64 features fi
 To connect to the GDB server, launch GDB with the following command.
 
 ```sh
-gdb-multiarch -ex "target remote localhost:5555" -ex "source MU_FEATURE_DEBUGGER/BaseTools/Scripts/efi_gdb.py"
+gdb-multiarch -ex "target remote localhost:5555" -ex "source MU_FEATURE_DEBUGGER/Scripts/efi_gdb.py"
 ```
 
 `target remote localhost:5555` will attach to the GDB port and
-`source MU_FEATURE_DEBUGGER/BaseTools/Scripts/efi_gdb.py` will load symbols from a local
+`source MU_FEATURE_DEBUGGER/Scripts/efi_gdb.py` will load symbols from a local
 build and add some UEFI commands. The target command can be altered for port, or
 device as needed.
 
@@ -239,7 +239,7 @@ using the [C/C++ Extension](https://marketplace.visualstudio.com/items?itemName=
 Note that the `program` value is just to satisy the extension. It must be a valid
 application, but will not matter for the actual debugging.
 
-After connecting, run `-exec source MU_FEATURE_DEBUGGER/BaseTools/Scripts/efi_gdb.py` from
+After connecting, run `-exec source MU_FEATURE_DEBUGGER/Scripts/efi_gdb.py` from
 the `DEBUG CONSOLE` tab to load symbols. This will require that the debugger be
 stepped or executed before the symbols will take place.
 
@@ -254,7 +254,7 @@ can be changed as appropriate.
 # AARCH64
 gdbgui -g "gdb-multiarch -ex 'target remote localhost:5555' -ex 'source MU_FEATURE_DEBUGGER/Scripts/efi_gdb.py'"
 # X64
-gdbgui -g "gdb -ex 'target remote localhost:5555' -ex 'source MU_FEATURE_DEBUGGER/BaseTools/Scripts/efi_gdb.py'"
+gdbgui -g "gdb -ex 'target remote localhost:5555' -ex 'source MU_FEATURE_DEBUGGER/Scripts/efi_gdb.py'"
 ```
 
 ## Custom GDB Server Commands

--- a/DebuggerFeaturePkg/Readme.md
+++ b/DebuggerFeaturePkg/Readme.md
@@ -205,11 +205,11 @@ GDB is currently only functional with AARCH64 due to bugs in the x64 features fi
 To connect to the GDB server, launch GDB with the following command.
 
 ```sh
-gdb-multiarch -ex "target remote localhost:5555" -ex "source MU_BASECORE/BaseTools/Scripts/efi_gdb.py"
+gdb-multiarch -ex "target remote localhost:5555" -ex "source MU_FEATURE_DEBUGGER/BaseTools/Scripts/efi_gdb.py"
 ```
 
 `target remote localhost:5555` will attach to the GDB port and
-`source MU_BASECORE/BaseTools/Scripts/efi_gdb.py` will load symbols from a local
+`source MU_FEATURE_DEBUGGER/BaseTools/Scripts/efi_gdb.py` will load symbols from a local
 build and add some UEFI commands. The target command can be altered for port, or
 device as needed.
 
@@ -239,7 +239,7 @@ using the [C/C++ Extension](https://marketplace.visualstudio.com/items?itemName=
 Note that the `program` value is just to satisy the extension. It must be a valid
 application, but will not matter for the actual debugging.
 
-After connecting, run `-exec source MU_BASECORE/BaseTools/Scripts/efi_gdb.py` from
+After connecting, run `-exec source MU_FEATURE_DEBUGGER/BaseTools/Scripts/efi_gdb.py` from
 the `DEBUG CONSOLE` tab to load symbols. This will require that the debugger be
 stepped or executed before the symbols will take place.
 
@@ -252,9 +252,9 @@ can be changed as appropriate.
 
 ```sh
 # AARCH64
-gdbgui -g "gdb-multiarch -ex 'target remote localhost:5555' -ex 'source MU_BASECORE/BaseTools/Scripts/efi_gdb.py'"
+gdbgui -g "gdb-multiarch -ex 'target remote localhost:5555' -ex 'source MU_FEATURE_DEBUGGER/Scripts/efi_gdb.py'"
 # X64
-gdbgui -g "gdb -ex 'target remote localhost:5555' -ex 'source MU_BASECORE/BaseTools/Scripts/efi_gdb.py'"
+gdbgui -g "gdb -ex 'target remote localhost:5555' -ex 'source MU_FEATURE_DEBUGGER/BaseTools/Scripts/efi_gdb.py'"
 ```
 
 ## Custom GDB Server Commands

--- a/Scripts/ComToTcpServer.py
+++ b/Scripts/ComToTcpServer.py
@@ -48,6 +48,10 @@ def socket_thread():
         conn, addr = sock.accept()
         print(f"Socket Connected - {addr}")
 
+        # clear the out queue before starting a connection
+        while not out_queue.empty():
+            out_queue.get()
+
         # use a short timeout to move on if no data is ready.
         conn.settimeout(0.01)
 


### PR DESCRIPTION
## Description

out_queue contains last buffered serial log contents from the com port. This could be mistaken as a response to the in_queue commands. This change empties the queue before making connection.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on gdbgui/vscode extension/gdb-multiarch commandline/windbgx.

## Integration Instructions

N/A