### PR TITLE
UefiExt: Automatically scroll through truncated commands

### DIFF
--- a/UefiDbgExt/swdebug.cpp
+++ b/UefiDbgExt/swdebug.cpp
@@ -159,11 +159,15 @@ monitor (
   INIT_API ();
 
   Offset = 0;
+
+  // Loop on the command until the entire response is received.
   while (TRUE) {
     Response = MonitorCommandWithOutput (Client, args, Offset);
 
+    // Strip of the trailing newline character if it exists since this in injected
+    // by windbg and is not part of the response.
     Len = strlen (Response);
-    if (Response[Len - 1] == '\n') {
+    if ((Len > 0) && (Response[Len - 1] == '\n')) {
       Len--;
     }
 

--- a/UefiDbgExt/uefiext.h
+++ b/UefiDbgExt/uefiext.h
@@ -92,7 +92,8 @@ ExecuteCommandWithOutput (
 PSTR
 MonitorCommandWithOutput (
   PDEBUG_CLIENT4  Client,
-  PCSTR           MonitorCommand
+  PCSTR           MonitorCommand,
+  ULONG           Offset
   );
 
 std::string

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -16,4 +16,4 @@ edk2-pytool-library~=0.23.2
 edk2-pytool-extensions~=0.29.2
 antlr4-python3-runtime==4.13.2
 regex
-pygount==2.0.0
+pygount==3.1.0


### PR DESCRIPTION
## Description

When detecting a `#T#` truncation tag, automatically request the next buffer in the command.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Test on Q35

## Integration Instructions

N/A
