### PR TITLE
Fixes monitor to respond OK and updates UefiEXT

### DIFF
--- a/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStub.c
+++ b/DebuggerFeaturePkg/Library/DebugAgent/GdbStub/GdbStub.c
@@ -580,9 +580,14 @@ ProcessMonitorCmd (
       break;
   }
 
-  // RCmd commands return hex encoded responses, convert to HEX before sending.
-  ConvertResponseToHex (&mScratch[0], mResponse, MAX_RESPONSE_SIZE);
+  // Respond with a intermediate packet, "O[HEX]" follow by an empty "OK" packet
+  // where the [HEX] is the hex encoding of the response string. The spec is
+  // vague on the need for this, but this is to be consistent with other GDB stub
+  // implementations and Windbg expectations.
+  mResponse[0] = 'O';
+  ConvertResponseToHex (&mScratch[0], &mResponse[1], MAX_RESPONSE_SIZE - 1);
   SendGdbResponse (mResponse);
+  SendGdbResponse ("OK");
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes the monitor response to use the intermediate packet followed by an `OK` instead of the imemediate packet. This is more consistent with other implementations and leaves up the ability to send responses in part in the future.

Additionally, this updated the UefiExt to handle the OK that now gets appended to the response as well as fixup handling of larger responses to no longer rely on a static buffer limit.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Q35 with Windbg

## Integration Instructions

N/A
