### PR TITLE
UefiExt: Use String Len Not Sizeof

### DIFF
--- a/UefiDbgExt/swdebug.cpp
+++ b/UefiDbgExt/swdebug.cpp
@@ -174,7 +174,7 @@ monitor (
     if (Len > TruncateTagLen) {
       if (strncmp (Response + Len - TruncateTagLen, TruncateTag, TruncateTagLen) == 0) {
         // The response was truncated, so we need to read more.
-        Response[Len - sizeof (TruncateTag)] = 0; // Remove the truncate tag.
+        Response[Len - TruncateTagLen] = 0; // Remove the truncate tag.
         dprintf ("%s", Response);
         Offset += Len - TruncateTagLen;
         continue;


### PR DESCRIPTION
## Description

When calculating what to print when a truncated message is sent from the debugger, UefiExt was using sizeof(CHAR8 *) which ended up removing valid characters that the target debugger had sent.

This fixes it to use the length, not size of the pointer.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested by using multi-packet monitor commands.

## Integration Instructions

N/A.
