### PR TITLE
Add CompilerIntrinsicsLib for ARM64.

### DIFF
--- a/DebuggerFeaturePkg/DebuggerFeaturePkg.dsc
+++ b/DebuggerFeaturePkg/DebuggerFeaturePkg.dsc
@@ -18,6 +18,13 @@
   BUILD_TARGETS                  = DEBUG|RELEASE|NOOPT
   SKUID_IDENTIFIER               = DEFAULT
 
+# memcpy and memset are difficult to avoid, esp. on ARM64.
+# e.g. struct/union/array init/assign, passing va_list by value in PrintLib.
+# Therefore link CompilerIntrinsicsLib everywhere (NULL class).
+# Current upstream AMD64 CompilerIntrinsicsLib does not compile but future does.
+[LibraryClasses.AARCH64]
+  NULL|MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
+
 [LibraryClasses]
   DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
   BaseLib|MdePkg/Library/BaseLib/BaseLib.inf


### PR DESCRIPTION
## Description

This is kinda preemptive/speculative.
In general, we are seeing link failures for memcpy and memset in various places, when compiling with clang and/or gcc.
gcc is "worse", but clang has had problems too.
I have seen a few things:
 - struct copy
 - struct initialization
 - passing struct by value; including va_list in PrintLib

I intend to try spot fixing them, but it seems prudent as well perhaps to use CompilerIntrinsicsLib more often.
Depending on version, the AMD64 library fails to compile (problems have seen on AMD64 also).
So this only adds ARM64.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

None of the above.
It just seems prudent to do this proactively.

## How This Was Tested

CI

## Integration Instructions

Nothing special.
Eventually it might be good to do this for all architectures, but until recently AMD64 did not compile.